### PR TITLE
fix: restore Elite 2 paddle and guide routing

### DIFF
--- a/Helpers/XboxEliteHelper.swift
+++ b/Helpers/XboxEliteHelper.swift
@@ -7,32 +7,37 @@
 // IOKit HID access to the Elite Series 2 over BLE. By running in a separate
 // process that doesn't link the framework, we can read raw HID events directly.
 //
-// Output: JSON lines to stdout for button state changes
+// Output: JSON lines to stdout for button state changes.
+// Pass --guide-only when GameController already exposes paddles.
 //   {"type":"guide","pressed":true}
 //   {"type":"guide","pressed":false}
 //   {"type":"paddle","index":1,"pressed":true}   (P1 = upper left)
-//   {"type":"paddle","index":2,"pressed":true}   (P2 = lower left)
-//   {"type":"paddle","index":3,"pressed":true}   (P3 = upper right)
+//   {"type":"paddle","index":2,"pressed":true}   (P2 = upper right)
+//   {"type":"paddle","index":3,"pressed":true}   (P3 = lower left)
 //   {"type":"paddle","index":4,"pressed":true}   (P4 = lower right)
 //
-// Xbox Elite 2 BLE HID Report ID 1 layout:
-//   Byte 10: Buttons 1-8  (A, B, X, Y, LB, RB, View, Menu)
-//   Byte 11: Buttons 9-15 + Consumer 0xB2
-//     bit 4 = Button 13 (Guide)
+// Xbox Elite 2 Guide varies by connection/firmware:
+//   Consumer Page 0x0223 = Classic Bluetooth Guide
+//   Button Page 13 = BLE Guide unless the descriptor has extended buttons
+//   Button Page 17 = USB Guide unless the device exposes Consumer AC Home
 //
 // Consumer Page 0x81 (4-bit bitmask for paddles):
-//   bit 0 = P3 (upper right)
+//   bit 0 = P2 (upper right)
 //   bit 1 = P4 (lower right)
 //   bit 2 = P1 (upper left)
-//   bit 3 = P2 (lower left)
+//   bit 3 = P3 (lower left)
 
 import Foundation
 import IOKit.hid
 
 // MARK: - State
 
+let shouldEmitPaddles = !CommandLine.arguments.contains("--guide-only")
 var guidePressed = false
 var paddleState: [Int: Bool] = [1: false, 2: false, 3: false, 4: false]
+var knownDevices = Set<UnsafeMutableRawPointer>()
+var devicesWithExtendedButtons = Set<UnsafeMutableRawPointer>()
+var devicesWithACHome = Set<UnsafeMutableRawPointer>()
 
 // Disable stdout buffering for immediate JSON line delivery
 setbuf(stdout, nil)
@@ -52,14 +57,79 @@ IOHIDManagerSetDeviceMatching(manager, matching)
 // Elite Series 2 PIDs
 let elitePIDs: Set<Int> = [0x0B00, 0x0B02, 0x0B05, 0x0B22]
 
+func isEliteDevice(_ device: IOHIDDevice) -> Bool {
+	let pid = IOHIDDeviceGetProperty(device, kIOHIDProductIDKey as CFString) as? Int ?? 0
+	return elitePIDs.contains(pid)
+}
+
+func guideTraits(for device: IOHIDDevice) -> (hasExtendedButtons: Bool, hasACHome: Bool) {
+	guard let elements = IOHIDDeviceCopyMatchingElements(device, nil, IOOptionBits(kIOHIDOptionsTypeNone)) as? [IOHIDElement] else {
+		return (false, false)
+	}
+
+	var maxButtonUsage: UInt32 = 0
+	var hasACHome = false
+	for element in elements {
+		let usagePage = IOHIDElementGetUsagePage(element)
+		if usagePage == UInt32(kHIDPage_Button) {
+			let usage = IOHIDElementGetUsage(element)
+			if usage > maxButtonUsage { maxButtonUsage = usage }
+		} else if usagePage == UInt32(kHIDPage_Consumer) && IOHIDElementGetUsage(element) == 0x0223 {
+			hasACHome = true
+		}
+	}
+
+	return (maxButtonUsage > 15, hasACHome)
+}
+
+func cachedGuideTraits(for device: IOHIDDevice) -> (hasExtendedButtons: Bool, hasACHome: Bool) {
+	let ptr = Unmanaged.passUnretained(device).toOpaque()
+	if !knownDevices.contains(ptr) {
+		let traits = guideTraits(for: device)
+		knownDevices.insert(ptr)
+		if traits.hasExtendedButtons {
+			devicesWithExtendedButtons.insert(ptr)
+		}
+		if traits.hasACHome {
+			devicesWithACHome.insert(ptr)
+		}
+	}
+
+	return (devicesWithExtendedButtons.contains(ptr), devicesWithACHome.contains(ptr))
+}
+
+func isGuideEvent(usagePage: UInt32, usage: UInt32, hasExtendedButtons: Bool, hasACHome: Bool) -> Bool {
+	if usagePage == UInt32(kHIDPage_Consumer) && usage == 0x0223 {
+		return true
+	}
+
+	guard usagePage == UInt32(kHIDPage_Button) else { return false }
+
+	if usage == 13 {
+		return !hasExtendedButtons
+	}
+	if usage == 17 {
+		return !hasACHome
+	}
+	return false
+}
+
 let inputCallback: IOHIDValueCallback = { _, _, _, value in
     let element = IOHIDValueGetElement(value)
     let usagePage = IOHIDElementGetUsagePage(element)
     let usage = IOHIDElementGetUsage(element)
     let intValue = IOHIDValueGetIntegerValue(value)
+	let device = IOHIDElementGetDevice(element)
 
-    // Guide button: Button Page, usage 13
-    if usagePage == UInt32(kHIDPage_Button) && usage == 13 {
+	guard isEliteDevice(device) else { return }
+
+	let traits = cachedGuideTraits(for: device)
+	if isGuideEvent(
+		usagePage: usagePage,
+		usage: usage,
+		hasExtendedButtons: traits.hasExtendedButtons,
+		hasACHome: traits.hasACHome
+	) {
         let pressed = intValue != 0
         if pressed != guidePressed {
             guidePressed = pressed
@@ -68,7 +138,7 @@ let inputCallback: IOHIDValueCallback = { _, _, _, value in
     }
 
     // Paddles: Consumer Page, usage 0x81 (4-bit bitmask)
-    if usagePage == UInt32(kHIDPage_Consumer) && usage == 0x81 {
+	if shouldEmitPaddles && usagePage == UInt32(kHIDPage_Consumer) && usage == 0x81 {
         let mask = intValue
         // Matches GCXboxGamepad convention: P1=upper left, P2=upper right, P3=lower left, P4=lower right
         let mapping: [(bit: Int, paddle: Int)] = [
@@ -93,6 +163,7 @@ let inputCallback: IOHIDValueCallback = { _, _, _, value in
 let deviceCallback: IOHIDDeviceCallback = { _, _, _, device in
     let pid = IOHIDDeviceGetProperty(device, kIOHIDProductIDKey as CFString) as? Int ?? 0
     if elitePIDs.contains(pid) {
+		_ = cachedGuideTraits(for: device)
         // Signal to parent that we found an Elite controller
         emit("{\"type\":\"connected\",\"pid\":\(pid)}")
     }
@@ -108,6 +179,7 @@ if let devices = IOHIDManagerCopyDevices(manager) as? Set<IOHIDDevice> {
     for device in devices {
         let pid = IOHIDDeviceGetProperty(device, kIOHIDProductIDKey as CFString) as? Int ?? 0
         if elitePIDs.contains(pid) {
+			_ = cachedGuideTraits(for: device)
             emit("{\"type\":\"connected\",\"pid\":\(pid)}")
         }
     }

--- a/Helpers/XboxEliteHelper.swift
+++ b/Helpers/XboxEliteHelper.swift
@@ -98,6 +98,19 @@ func cachedGuideTraits(for device: IOHIDDevice) -> (hasExtendedButtons: Bool, ha
 	return (devicesWithExtendedButtons.contains(ptr), devicesWithACHome.contains(ptr))
 }
 
+func eliteSessionGuideTraits() -> (hasExtendedButtons: Bool, hasACHome: Bool) {
+	(!devicesWithExtendedButtons.isEmpty, !devicesWithACHome.isEmpty)
+}
+
+func effectiveGuideTraits(for device: IOHIDDevice) -> (hasExtendedButtons: Bool, hasACHome: Bool) {
+	let traits = cachedGuideTraits(for: device)
+	let sessionTraits = eliteSessionGuideTraits()
+	return (
+		traits.hasExtendedButtons || sessionTraits.hasExtendedButtons,
+		traits.hasACHome || sessionTraits.hasACHome
+	)
+}
+
 func isGuideEvent(usagePage: UInt32, usage: UInt32, hasExtendedButtons: Bool, hasACHome: Bool) -> Bool {
 	if usagePage == UInt32(kHIDPage_Consumer) && usage == 0x0223 {
 		return true
@@ -123,7 +136,7 @@ let inputCallback: IOHIDValueCallback = { _, _, _, value in
 
 	guard isEliteDevice(device) else { return }
 
-	let traits = cachedGuideTraits(for: device)
+	let traits = effectiveGuideTraits(for: device)
 	if isGuideEvent(
 		usagePage: usagePage,
 		usage: usage,

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,24 @@ APP_PATH := $(TARGET_BUILD_DIR)/$(WRAPPER_NAME)
 PROCESS_NAME := $(basename $(WRAPPER_NAME))
 
 # Check if an Apple Development cert is available for local development signing.
-APPLE_DEVELOPMENT_IDENTITY := $(shell security find-identity -v -p codesigning 2>/dev/null | awk '/Apple Development:/ {print $$2; exit}')
+# Restrict to the configured team so a different team's certificate does not force
+# the signed build path before xcodebuild can fall back to ad-hoc signing.
+APPLE_DEVELOPMENT_IDENTITY := $(shell \
+	valid_identities=$$(security find-identity -v -p codesigning 2>/dev/null | awk '/Apple Development:/ {printf " %s ", $$2}'); \
+	tmp_dir=$$(mktemp -d 2>/dev/null || mktemp -d -t xcm-cert); \
+	trap 'rm -rf "$$tmp_dir"' EXIT; \
+	security find-certificate -a -c "Apple Development" -Z -p 2>/dev/null | \
+	awk -v dir="$$tmp_dir" '/^SHA-1 hash:/ { hash=$$3 } /^-----BEGIN CERTIFICATE-----/ { in_cert=1; cert=$$0 ORS; next } in_cert { cert=cert $$0 ORS } /^-----END CERTIFICATE-----/ && hash != "" { file=dir "/" hash ".pem"; print cert > file; cert=""; in_cert=0; next } /^-----END CERTIFICATE-----/ { cert=""; in_cert=0 }'; \
+	for cert in "$$tmp_dir"/*.pem; do \
+		[ -e "$$cert" ] || continue; \
+		hash=$$(basename "$$cert" .pem); \
+		printf '%s' "$$valid_identities" | grep -Fq " $$hash " || continue; \
+		subject=$$(openssl x509 -in "$$cert" -noout -subject 2>/dev/null); \
+		if printf '%s' "$$subject" | grep -Fq "OU=$(TEAM_ID)" || printf '%s' "$$subject" | grep -Fq "OU = $(TEAM_ID)"; then \
+			echo "$$hash"; \
+			break; \
+		fi; \
+	done)
 HAS_DEV_CERT := $(shell [ -n "$(APPLE_DEVELOPMENT_IDENTITY)" ] && echo 1 || echo 0)
 
 INFO_PLIST := XboxControllerMapper/XboxControllerMapper/Info.plist

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,9 @@ WRAPPER_NAME := $(shell $(BUILD_SETTINGS) | awk -F ' = ' '/WRAPPER_NAME/ {print 
 APP_PATH := $(TARGET_BUILD_DIR)/$(WRAPPER_NAME)
 PROCESS_NAME := $(basename $(WRAPPER_NAME))
 
-# Check if Kevin's dev cert is available (team ID 542GXYT5Z2)
-HAS_DEV_CERT := $(shell security find-identity -v -p codesigning 2>/dev/null | grep -q "$(TEAM_ID)" && echo 1 || echo 0)
+# Check if an Apple Development cert is available for local development signing.
+APPLE_DEVELOPMENT_IDENTITY := $(shell security find-identity -v -p codesigning 2>/dev/null | awk '/Apple Development:/ {print $$2; exit}')
+HAS_DEV_CERT := $(shell [ -n "$(APPLE_DEVELOPMENT_IDENTITY)" ] && echo 1 || echo 0)
 
 INFO_PLIST := XboxControllerMapper/XboxControllerMapper/Info.plist
 
@@ -106,11 +107,24 @@ endif
 
 install: build elite-helper
 	-pkill -x "$(PROCESS_NAME)" || true
+	-pkill -x "$(HELPER_NAME)" || true
 	@sleep 1
 	/usr/bin/ditto "$(APP_PATH)" "/Applications/$(WRAPPER_NAME)"
 	@# Bundle the Elite helper inside the app
 	@mkdir -p "/Applications/$(WRAPPER_NAME)/Contents/Helpers"
 	@cp "$(TARGET_BUILD_DIR)/$(HELPER_NAME)" "/Applications/$(WRAPPER_NAME)/Contents/Helpers/$(HELPER_NAME)"
+ifeq ($(HAS_DEV_CERT),1)
+	@CERT_PREFIX="/tmp/xcm-app-signing-cert-$$$$"; \
+	/usr/bin/codesign -d --extract-certificates="$$CERT_PREFIX" "$(APP_PATH)" >/dev/null 2>&1; \
+	SIGNING_IDENTITY="$$(openssl x509 -inform DER -in "$${CERT_PREFIX}0" -noout -fingerprint -sha1 | sed 's/.*=//; s/://g')"; \
+	rm -f "$${CERT_PREFIX}"*; \
+	echo "Signing Elite helper with app identity $$SIGNING_IDENTITY"; \
+	/usr/bin/codesign --force --sign "$$SIGNING_IDENTITY" --timestamp=none "/Applications/$(WRAPPER_NAME)/Contents/Helpers/$(HELPER_NAME)"; \
+	/usr/bin/codesign --force --sign "$$SIGNING_IDENTITY" --timestamp=none --preserve-metadata=entitlements,requirements,flags "/Applications/$(WRAPPER_NAME)"
+else
+	/usr/bin/codesign --force --sign - --timestamp=none "/Applications/$(WRAPPER_NAME)/Contents/Helpers/$(HELPER_NAME)"
+	/usr/bin/codesign --force --sign - --timestamp=none --preserve-metadata=entitlements,requirements,flags "/Applications/$(WRAPPER_NAME)"
+endif
 	@echo "Installed to /Applications/$(WRAPPER_NAME)"
 	open "/Applications/$(WRAPPER_NAME)"
 

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService+EliteHelper.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService+EliteHelper.swift
@@ -11,9 +11,25 @@ import Foundation
 @MainActor
 extension ControllerService {
 
-    func startEliteHelper() {
-        // Don't start if already running
-        guard eliteHelperProcess == nil else { return }
+	func startEliteHelper(paddleEventSource: ElitePaddleEventSource) {
+		let handlePaddles = EliteControllerInputPolicy.helperHandlesPaddles(
+			paddleEventSource: paddleEventSource
+		)
+		if let process = eliteHelperProcess {
+			if process.isRunning {
+				guard EliteControllerInputPolicy.helperNeedsRestart(
+					currentHandlePaddles: eliteHelperHandlesPaddles,
+					requestedHandlePaddles: handlePaddles
+				) else {
+					return
+				}
+				guideLog("Restarting Elite helper process for paddle mode change")
+				stopEliteHelper()
+			} else {
+				eliteHelperProcess = nil
+				eliteHelperHandlesPaddles = nil
+			}
+		}
 
         let helperPath = Bundle.main.bundlePath + "/Contents/Helpers/XboxEliteHelper"
 
@@ -26,6 +42,9 @@ extension ControllerService {
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: helperPath)
+		process.arguments = EliteControllerInputPolicy.helperArguments(
+			paddleEventSource: paddleEventSource
+		)
 
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -37,8 +56,10 @@ extension ControllerService {
             guard !data.isEmpty else {
                 // EOF — process terminated. Clear the handler to stop repeated calls.
                 handle.readabilityHandler = nil
-                DispatchQueue.main.async { [weak self] in
-                    self?.eliteHelperProcess = nil
+				DispatchQueue.main.async { [weak self, weak process] in
+					guard let self, let process, self.eliteHelperProcess === process else { return }
+					self.eliteHelperProcess = nil
+					self.eliteHelperHandlesPaddles = nil
                     guideLog("Elite helper process terminated (EOF)")
                 }
                 return
@@ -58,6 +79,7 @@ extension ControllerService {
         do {
             try process.run()
             eliteHelperProcess = process
+			eliteHelperHandlesPaddles = handlePaddles
             guideLog("Elite helper process started (pid \(process.processIdentifier))")
         } catch {
             guideLog("Failed to start Elite helper: \(error)")
@@ -67,11 +89,13 @@ extension ControllerService {
     func stopEliteHelper() {
         guard let process = eliteHelperProcess, process.isRunning else {
             eliteHelperProcess = nil
+			eliteHelperHandlesPaddles = nil
             return
         }
         guideLog("Stopping Elite helper process")
         process.terminate()
         eliteHelperProcess = nil
+		eliteHelperHandlesPaddles = nil
     }
 
     private nonisolated func handleEliteHelperLine(_ line: String) {
@@ -99,14 +123,7 @@ extension ControllerService {
 
         case "paddle":
             if let index = json["index"] as? Int, let pressed = json["pressed"] as? Bool {
-                let button: ControllerButton
-                switch index {
-                case 1: button = .xboxPaddle1
-                case 2: button = .xboxPaddle2
-                case 3: button = .xboxPaddle3
-                case 4: button = .xboxPaddle4
-                default: return
-                }
+				guard let button = eliteHelperPaddleButton(for: index, pressed: pressed) else { return }
                 guideLog("Elite helper: Paddle \(index) \(pressed ? "PRESSED" : "RELEASED")")
                 controllerQueue.async { [weak self] in
                     self?.handleButton(button, pressed: pressed)
@@ -117,4 +134,30 @@ extension ControllerService {
             break
         }
     }
+}
+
+enum ElitePaddleEventSource: Equatable, Sendable {
+	case none
+	case rawHID
+}
+
+enum EliteControllerInputPolicy {
+	static func paddleEventSource(gameControllerHasPaddles: Bool) -> ElitePaddleEventSource {
+		gameControllerHasPaddles ? .none : .rawHID
+	}
+
+	static func helperHandlesPaddles(paddleEventSource: ElitePaddleEventSource) -> Bool {
+		paddleEventSource == .rawHID
+	}
+
+	static func helperArguments(paddleEventSource: ElitePaddleEventSource) -> [String] {
+		helperHandlesPaddles(paddleEventSource: paddleEventSource) ? [] : ["--guide-only"]
+	}
+
+	static func helperNeedsRestart(
+		currentHandlePaddles: Bool?,
+		requestedHandlePaddles: Bool
+	) -> Bool {
+		currentHandlePaddles != requestedHandlePaddles
+	}
 }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService.swift
@@ -82,6 +82,11 @@ final class ControllerStorage: @unchecked Sendable {
     var lastLeftFunctionState: Bool = false
     var lastRightFunctionState: Bool = false
 
+	// Elite raw HID paddle producers are centrally deduped here because helper and guide monitor
+	// visibility differs by Elite 2 firmware/connection mode.
+	var elitePaddleEventSource: ElitePaddleEventSource = .none
+	var eliteRawPaddleState: [Int: Bool] = [:]
+
     // Chord Detection State
     var pendingButtons: Set<ControllerButton> = []
     var capturedButtonsInWindow: Set<ControllerButton> = []
@@ -221,6 +226,7 @@ class ControllerService: ObservableObject {
 
     /// Xbox Elite Series 2 helper process (separate binary without GameController.framework)
     var eliteHelperProcess: Process?
+	var eliteHelperHandlesPaddles: Bool?
 
     enum TouchpadIdleSentinelConfig {
         static let activationThreshold: CGFloat = 0.02
@@ -564,7 +570,7 @@ class ControllerService: ObservableObject {
     private var cancellables = Set<AnyCancellable>()
 
     // Low-level monitor for Xbox Guide button
-    private let guideMonitor = XboxGuideMonitor()
+	private let guideMonitor: XboxGuideMonitor
 
     // Low-level monitor for Battery (Bluetooth Workaround for macOS/Xbox issue)
     private let batteryMonitor = BluetoothBatteryMonitor()
@@ -582,6 +588,7 @@ class ControllerService: ObservableObject {
 
     init(enableHardwareMonitoring: Bool = true) {
         let shouldEnableHardwareMonitoring = enableHardwareMonitoring && !Self.isRunningTests
+		self.guideMonitor = XboxGuideMonitor(enableHardwareMonitoring: shouldEnableHardwareMonitoring)
 
         // Load last controller type (so UI shows correct button labels when no controller is connected)
         storage.isDualSense = UserDefaults.standard.bool(forKey: Config.lastControllerWasDualSenseKey)
@@ -612,14 +619,7 @@ class ControllerService: ObservableObject {
         }
 
         guideMonitor.onPaddleAction = { [weak self] paddleIndex, isPressed in
-            let button: ControllerButton
-            switch paddleIndex {
-            case 1: button = .xboxPaddle1
-            case 2: button = .xboxPaddle2
-            case 3: button = .xboxPaddle3
-            case 4: button = .xboxPaddle4
-            default: return
-            }
+			guard let button = self?.guideMonitorPaddleButton(for: paddleIndex, pressed: isPressed) else { return }
             self?.controllerQueue.async { [weak self] in
                 self?.handleButton(button, pressed: isPressed)
             }
@@ -767,6 +767,8 @@ class ControllerService: ObservableObject {
         storage.lastRightPaddleState = false
         storage.lastLeftFunctionState = false
         storage.lastRightFunctionState = false
+		storage.elitePaddleEventSource = .none
+		storage.eliteRawPaddleState.removeAll()
         storage.lock.unlock()
     }
 
@@ -796,6 +798,36 @@ class ControllerService: ObservableObject {
         storage.touchpadHasSeenTouch = false
         storage.touchpadSecondaryHasSeenTouch = false
     }
+
+	nonisolated func guideMonitorPaddleButton(for paddleIndex: Int, pressed: Bool) -> ControllerButton? {
+		eliteRawHIDPaddleButton(for: paddleIndex, pressed: pressed)
+	}
+
+	nonisolated func eliteHelperPaddleButton(for paddleIndex: Int, pressed: Bool) -> ControllerButton? {
+		eliteRawHIDPaddleButton(for: paddleIndex, pressed: pressed)
+	}
+
+	private nonisolated func eliteRawHIDPaddleButton(for paddleIndex: Int, pressed: Bool) -> ControllerButton? {
+		guard let button = Self.xboxElitePaddleButton(for: paddleIndex) else { return nil }
+		storage.lock.lock()
+		defer { storage.lock.unlock() }
+		guard storage.elitePaddleEventSource == .rawHID else { return nil }
+		if storage.eliteRawPaddleState[paddleIndex] == pressed {
+			return nil
+		}
+		storage.eliteRawPaddleState[paddleIndex] = pressed
+		return button
+	}
+
+	nonisolated static func xboxElitePaddleButton(for paddleIndex: Int) -> ControllerButton? {
+		switch paddleIndex {
+		case 1: return .xboxPaddle1
+		case 2: return .xboxPaddle2
+		case 3: return .xboxPaddle3
+		case 4: return .xboxPaddle4
+		default: return nil
+		}
+	}
 
     // MARK: - Display Update Timer
 
@@ -1204,6 +1236,13 @@ class ControllerService: ObservableObject {
             return
         }
 
+		let xboxGamepad = gamepad as? GCXboxGamepad
+		let xboxGamepadHasPaddles = xboxGamepad.map {
+			$0.paddleButton1 != nil || $0.paddleButton2 != nil || $0.paddleButton3 != nil || $0.paddleButton4 != nil
+		} ?? false
+		let isXboxEliteByPID = xboxGamepad != nil && (guideMonitor.isEliteControllerConnected || Self.isEliteByHIDEnumeration())
+		let isXboxElite = xboxGamepadHasPaddles || isXboxEliteByPID
+
         // Face buttons
         bindButton(gamepad.buttonA, to: .a)
         bindButton(gamepad.buttonB, to: .b)
@@ -1231,7 +1270,9 @@ class ControllerService: ObservableObject {
         // Special buttons
         bindButton(gamepad.buttonMenu, to: .menu)
         bindButton(gamepad.buttonOptions, to: .view)
-        bindButton((gamepad as? GCExtendedGamepad)?.buttonHome, to: .xbox)
+		if !isXboxElite {
+			bindButton(gamepad.buttonHome, to: .xbox)
+		}
 
         // Log available elements for diagnostics (helps debug Joy-Con/third-party controllers)
         if storage.lock.withLock({ storage.isNintendo }) {
@@ -1284,7 +1325,7 @@ class ControllerService: ObservableObject {
             }
         }
 
-        if let xboxGamepad = gamepad as? GCXboxGamepad {
+		if let xboxGamepad {
             storage.lock.lock()
             storage.isDualSense = false
             storage.isDualSenseEdge = false
@@ -1306,12 +1347,16 @@ class ControllerService: ObservableObject {
             // Xbox Elite Series 2 detection:
             // 1. Paddle detection (paddles only report when no hardware profile is selected)
             // 2. PID-based detection via HID device enumeration (always works regardless of profile)
-            let hasPaddles = xboxGamepad.paddleButton1 != nil
-            let isEliteByPID = guideMonitor.isEliteControllerConnected || Self.isEliteByHIDEnumeration()
+			let hasPaddles = xboxGamepadHasPaddles
+			let isEliteByPID = isXboxEliteByPID
 
             if hasPaddles || isEliteByPID {
+				let paddleEventSource = EliteControllerInputPolicy.paddleEventSource(
+					gameControllerHasPaddles: hasPaddles
+				)
                 storage.lock.lock()
                 storage.isXboxElite = true
+				storage.elitePaddleEventSource = paddleEventSource
                 storage.lock.unlock()
                 UserDefaults.standard.set(true, forKey: Config.lastControllerWasXboxEliteKey)
                 controllerName = "Xbox Elite Series 2 Controller"
@@ -1323,13 +1368,14 @@ class ControllerService: ObservableObject {
                     bindButton(xboxGamepad.paddleButton4, to: .xboxPaddle4)
                 }
 
-                // Launch helper process for Guide button + paddle detection via raw HID.
+				// Launch helper process for Guide button and, when needed, paddle detection via raw HID.
                 // gamecontrollerd blocks IOKit HID access to Elite 2 over BLE when
                 // GameController.framework is loaded, so we use a separate process.
-                startEliteHelper()
+				startEliteHelper(paddleEventSource: paddleEventSource)
             } else {
                 storage.lock.lock()
                 storage.isXboxElite = false
+				storage.elitePaddleEventSource = .none
                 storage.lock.unlock()
                 UserDefaults.standard.set(false, forKey: Config.lastControllerWasXboxEliteKey)
             }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService.swift
@@ -626,12 +626,13 @@ class ControllerService: ObservableObject {
         }
     }
 
-    func cleanup() {
-        stopDiscovery()
-        batteryMonitor.stopMonitoring()
-        cleanupGenericHIDMonitoring()
-        stopEliteHelper()
-    }
+	func cleanup() {
+		guideMonitor.stop()
+		stopDiscovery()
+		batteryMonitor.stopMonitoring()
+		cleanupGenericHIDMonitoring()
+		stopEliteHelper()
+	}
 
     private func setupNotifications() {
         NotificationCenter.default.publisher(for: .GCControllerDidConnect)
@@ -1240,8 +1241,15 @@ class ControllerService: ObservableObject {
 		let xboxGamepadHasPaddles = xboxGamepad.map {
 			$0.paddleButton1 != nil || $0.paddleButton2 != nil || $0.paddleButton3 != nil || $0.paddleButton4 != nil
 		} ?? false
-		let isXboxEliteByPID = xboxGamepad != nil && (guideMonitor.isEliteControllerConnected || Self.isEliteByHIDEnumeration())
-		let isXboxElite = xboxGamepadHasPaddles || isXboxEliteByPID
+		let isXboxEliteByMetadata = xboxGamepad != nil && Self.isEliteControllerMetadata(
+			vendorName: controller.vendorName,
+			productCategory: controller.productCategory
+		)
+		let isXboxEliteByHIDFallback = xboxGamepad != nil
+			&& Self.shouldUseGlobalEliteHIDFallback(connectedXboxControllerCount: Self.connectedXboxControllerCount())
+			&& Self.isEliteByHIDEnumeration()
+		let isXboxEliteByIdentity = isXboxEliteByMetadata || isXboxEliteByHIDFallback
+		let isXboxElite = xboxGamepadHasPaddles || isXboxEliteByIdentity
 
         // Face buttons
         bindButton(gamepad.buttonA, to: .a)
@@ -1348,9 +1356,9 @@ class ControllerService: ObservableObject {
             // 1. Paddle detection (paddles only report when no hardware profile is selected)
             // 2. PID-based detection via HID device enumeration (always works regardless of profile)
 			let hasPaddles = xboxGamepadHasPaddles
-			let isEliteByPID = isXboxEliteByPID
+			let isEliteByIdentity = isXboxEliteByIdentity
 
-            if hasPaddles || isEliteByPID {
+			if hasPaddles || isEliteByIdentity {
 				let paddleEventSource = EliteControllerInputPolicy.paddleEventSource(
 					gameControllerHasPaddles: hasPaddles
 				)
@@ -1455,15 +1463,23 @@ class ControllerService: ObservableObject {
 
     }
 
-    // MARK: - Nintendo Controller Detection
+    // MARK: - Xbox Elite Controller Detection
 
-    /// Detects Nintendo controllers (Joy-Con, Pro Controller) via vendor name and product category.
-    /// Must be called before the extendedGamepad guard since single Joy-Cons only provide physicalInputProfile.
-    ///
-    /// Known productCategory values from GameController framework:
-    ///   "Nintendo Switch Joy-Con (L)", "Nintendo Switch Joy-Con (R)",
+    nonisolated static func isEliteControllerMetadata(vendorName: String?, productCategory: String) -> Bool {
+		let combined = ((vendorName ?? "") + " " + productCategory).lowercased()
+		return combined.contains("elite")
+	}
+
+    nonisolated static func shouldUseGlobalEliteHIDFallback(connectedXboxControllerCount: Int) -> Bool {
+		connectedXboxControllerCount <= 1
+	}
+
+    private static func connectedXboxControllerCount() -> Int {
+		GCController.controllers().filter { $0.extendedGamepad is GCXboxGamepad }.count
+	}
+
     /// One-shot HID enumeration to check if an Xbox Elite Series 2 is connected by PID.
-    /// Used as a fallback when the XboxGuideMonitor hasn't processed the device match yet.
+    /// Used only when a single Xbox controller is connected so it cannot classify the wrong active controller.
     private static func isEliteByHIDEnumeration() -> Bool {
         guard let manager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone)) as IOHIDManager? else {
             return false
@@ -1483,6 +1499,13 @@ class ControllerService: ObservableObject {
         return false
     }
 
+    // MARK: - Nintendo Controller Detection
+
+    /// Detects Nintendo controllers (Joy-Con, Pro Controller) via vendor name and product category.
+    /// Must be called before the extendedGamepad guard since single Joy-Cons only provide physicalInputProfile.
+    ///
+    /// Known productCategory values from GameController framework:
+    ///   "Nintendo Switch Joy-Con (L)", "Nintendo Switch Joy-Con (R)",
     ///   "Nintendo Switch Joy-Con (L/R)", "Switch Pro Controller"
     /// vendorName is the Bluetooth device name: "Joy-Con (L)", "Joy-Con (R)", "Pro Controller"
     private func detectNintendoController(_ controller: GCController) {

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/XboxGuideMonitor.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/XboxGuideMonitor.swift
@@ -58,6 +58,11 @@ class XboxGuideMonitor {
 	/// On these devices, Button Page usage 17 can be a normal mirrored face button.
 	private var devicesWithACHome = Set<UnsafeMutableRawPointer>()
 
+	/// Elite 2 often appears as multiple HID interfaces. If one interface reveals
+	/// Guide routing traits, apply those traits across the whole Elite session.
+	private var eliteDevicesWithExtendedButtons = Set<UnsafeMutableRawPointer>()
+	private var eliteDevicesWithACHome = Set<UnsafeMutableRawPointer>()
+
     /// Product IDs of currently connected Microsoft controller devices.
     /// Updated on device match/removal. Thread-safe via main queue (HID callbacks run on main).
     private(set) var connectedMicrosoftPIDs: Set<Int> = []
@@ -204,9 +209,24 @@ class XboxGuideMonitor {
         }
     }
 
-	private struct GuideTraits {
+	struct GuideTraits: Equatable {
 		let hasExtendedButtons: Bool
 		let hasACHome: Bool
+
+		static let none = GuideTraits(hasExtendedButtons: false, hasACHome: false)
+
+		func merged(with other: GuideTraits) -> GuideTraits {
+			GuideTraits(
+				hasExtendedButtons: hasExtendedButtons || other.hasExtendedButtons,
+				hasACHome: hasACHome || other.hasACHome
+			)
+		}
+	}
+
+	private static func isEliteDevice(_ device: IOHIDDevice) -> Bool {
+		let vid = IOHIDDeviceGetProperty(device, kIOHIDVendorIDKey as CFString) as? Int ?? 0
+		let pid = IOHIDDeviceGetProperty(device, kIOHIDProductIDKey as CFString) as? Int ?? 0
+		return vid == 0x045E && eliteSeries2PIDs.contains(pid)
 	}
 
 	/// Returns the HID guide routing traits for a device by enumerating its elements.
@@ -250,17 +270,31 @@ class XboxGuideMonitor {
 		return false
 	}
 
+	static func effectiveGuideTraits(
+		deviceTraits: GuideTraits,
+		eliteSessionTraits: GuideTraits
+	) -> GuideTraits {
+		deviceTraits.merged(with: eliteSessionTraits)
+	}
+
 	@discardableResult
 	private func cacheGuideTraits(for device: IOHIDDevice, shouldLog: Bool = false) -> GuideTraits {
 		let ptr = Unmanaged.passUnretained(device).toOpaque()
 		if !devicesWithKnownGuideTraits.contains(ptr) {
 			let traits = Self.guideTraits(for: device)
+			let isElite = Self.isEliteDevice(device)
 			devicesWithKnownGuideTraits.insert(ptr)
 			if traits.hasExtendedButtons {
 				devicesWithExtendedButtons.insert(ptr)
+				if isElite {
+					eliteDevicesWithExtendedButtons.insert(ptr)
+				}
 			}
 			if traits.hasACHome {
 				devicesWithACHome.insert(ptr)
+				if isElite {
+					eliteDevicesWithACHome.insert(ptr)
+				}
 			}
 			if shouldLog {
 				guideLog("  hasExtendedButtons=\(traits.hasExtendedButtons) hasACHome=\(traits.hasACHome)")
@@ -270,6 +304,10 @@ class XboxGuideMonitor {
 				if traits.hasACHome {
 					guideLog("  Guide = Consumer Page AC Home (0x0223)")
 				}
+				if isElite {
+					let sessionTraits = eliteSessionGuideTraits()
+					guideLog("  Elite session traits: hasExtendedButtons=\(sessionTraits.hasExtendedButtons) hasACHome=\(sessionTraits.hasACHome)")
+				}
             }
         }
 		return GuideTraits(
@@ -277,6 +315,24 @@ class XboxGuideMonitor {
 			hasACHome: devicesWithACHome.contains(ptr)
 		)
     }
+
+	private func eliteSessionGuideTraits() -> GuideTraits {
+		GuideTraits(
+			hasExtendedButtons: !eliteDevicesWithExtendedButtons.isEmpty,
+			hasACHome: !eliteDevicesWithACHome.isEmpty
+		)
+	}
+
+	private func effectiveGuideTraits(for device: IOHIDDevice) -> GuideTraits {
+		let deviceTraits = cacheGuideTraits(for: device)
+		guard Self.isEliteDevice(device) else {
+			return deviceTraits
+		}
+		return Self.effectiveGuideTraits(
+			deviceTraits: deviceTraits,
+			eliteSessionTraits: eliteSessionGuideTraits()
+		)
+	}
 
     fileprivate func deviceRemoved(_ device: IOHIDDevice) {
         guideLog("Device removed: \"\(getDeviceName(device))\"")
@@ -289,6 +345,8 @@ class XboxGuideMonitor {
 		devicesWithKnownGuideTraits.remove(ptr)
 		devicesWithExtendedButtons.remove(ptr)
 		devicesWithACHome.remove(ptr)
+		eliteDevicesWithExtendedButtons.remove(ptr)
+		eliteDevicesWithACHome.remove(ptr)
     }
 
     // MARK: - Input Value Handler
@@ -300,7 +358,7 @@ class XboxGuideMonitor {
         let intValue = IOHIDValueGetIntegerValue(value)
 
 		let device = IOHIDElementGetDevice(element)
-		let traits = cacheGuideTraits(for: device)
+		let traits = effectiveGuideTraits(for: device)
 		if Self.isGuideEvent(
 			usagePage: usagePage,
 			usage: usage,

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/XboxGuideMonitor.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/XboxGuideMonitor.swift
@@ -25,15 +25,15 @@ class XboxGuideMonitor {
 
     private var hidManager: IOHIDManager?
     private var callbackContext: UnsafeMutableRawPointer?
+	private var callbackContextHolder: CallbackContext?
     private(set) var isStarted = false
+	private let enableHardwareMonitoring: Bool
 
     // Paddle state tracking (Consumer Page 0x81 bitmask)
     private var paddleState: [Int: Bool] = [1: false, 2: false, 3: false, 4: false]
-    // Consumer 0x81 bitmask mapping: bit -> paddle index
-    // Matches GCXboxGamepad convention: P1=upper left, P2=upper right, P3=lower left, P4=lower right
-    //   bit 2 = P1 (upper left), bit 0 = P2 (upper right)
-    //   bit 3 = P3 (lower left), bit 1 = P4 (lower right)
-    private static let paddleBitMapping: [(bit: Int, paddle: Int)] = [
+	// Consumer 0x81 bitmask mapping: bit -> paddle index.
+	// Matches GCXboxGamepad convention: P1=upper left, P2=upper right, P3=lower left, P4=lower right.
+	static let paddleBitMapping: [(bit: Int, paddle: Int)] = [
         (2, 1), (0, 2), (3, 3), (1, 4)
     ]
 
@@ -47,10 +47,16 @@ class XboxGuideMonitor {
         0x0B22,  // Elite 2 (Bluetooth Low Energy — new firmware 5.x+)
     ]
 
-    /// Tracks devices where Button Page usage 13 is a paddle (not Guide).
-    /// On USB-style Elite 2 descriptors (>15 Button Page usages), usage 13 is a paddle
-    /// and Guide is at usage 17. On BLE-style descriptors (15 usages), usage 13 IS Guide.
-    private var devicesWhereUsage13IsPaddle = Set<UnsafeMutableRawPointer>()
+	/// Devices whose HID traits have already been inspected.
+	private var devicesWithKnownGuideTraits = Set<UnsafeMutableRawPointer>()
+
+	/// Tracks devices with >15 Button Page usages (USB-style/Classic BT descriptors).
+	/// On these devices, Button Page usage 13 is a paddle, not Guide.
+	private var devicesWithExtendedButtons = Set<UnsafeMutableRawPointer>()
+
+	/// Tracks devices that expose Consumer Page AC Home (0x0223) as Guide.
+	/// On these devices, Button Page usage 17 can be a normal mirrored face button.
+	private var devicesWithACHome = Set<UnsafeMutableRawPointer>()
 
     /// Product IDs of currently connected Microsoft controller devices.
     /// Updated on device match/removal. Thread-safe via main queue (HID callbacks run on main).
@@ -69,6 +75,8 @@ class XboxGuideMonitor {
     private final class CallbackContext {
         weak var monitor: XboxGuideMonitor?
         init(monitor: XboxGuideMonitor) { self.monitor = monitor }
+		// Avoid inferred MainActor-isolated teardown for this unmanaged HID callback holder.
+		nonisolated deinit { }
     }
 
     // MARK: - Static Callbacks
@@ -91,9 +99,29 @@ class XboxGuideMonitor {
         holder.monitor?.handleInput(value)
     }
 
+	private func prepareCallbackContext() -> UnsafeMutableRawPointer {
+		if let callbackContext {
+			return callbackContext
+		}
+		let holder = CallbackContext(monitor: self)
+		callbackContextHolder = holder
+		let context = Unmanaged.passUnretained(holder).toOpaque()
+		callbackContext = context
+		return context
+	}
+
+	var hasCallbackContextForTesting: Bool {
+		callbackContext != nil
+	}
+
+	func prepareCallbackContextForTesting() {
+		_ = prepareCallbackContext()
+	}
+
     // MARK: - Lifecycle
 
-    init() {
+	init(enableHardwareMonitoring: Bool = true) {
+		self.enableHardwareMonitoring = enableHardwareMonitoring
         start()
     }
 
@@ -103,6 +131,11 @@ class XboxGuideMonitor {
 
     func start() {
         guard !isStarted else { return }
+
+		guard enableHardwareMonitoring else {
+			isStarted = true
+			return
+		}
 
         hidManager = IOHIDManagerCreate(kCFAllocatorDefault, IOOptionBits(kIOHIDOptionsTypeNone))
         guard let hidManager = hidManager else { return }
@@ -126,11 +159,10 @@ class XboxGuideMonitor {
         let criteria = [gamepadMatching, joystickMatching, microsoftMatching] as CFArray
         IOHIDManagerSetDeviceMatchingMultiple(hidManager, criteria)
 
-        let retainedContext = Unmanaged.passRetained(CallbackContext(monitor: self)).toOpaque()
-        callbackContext = retainedContext
-        IOHIDManagerRegisterDeviceMatchingCallback(hidManager, Self.deviceMatchedCallback, retainedContext)
-        IOHIDManagerRegisterDeviceRemovalCallback(hidManager, Self.deviceRemovedCallback, retainedContext)
-        IOHIDManagerRegisterInputValueCallback(hidManager, Self.inputValueCallback, retainedContext)
+		let context = prepareCallbackContext()
+		IOHIDManagerRegisterDeviceMatchingCallback(hidManager, Self.deviceMatchedCallback, context)
+		IOHIDManagerRegisterDeviceRemovalCallback(hidManager, Self.deviceRemovedCallback, context)
+		IOHIDManagerRegisterInputValueCallback(hidManager, Self.inputValueCallback, context)
 
         IOHIDManagerScheduleWithRunLoop(hidManager, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
         _ = IOHIDManagerOpen(hidManager, IOOptionBits(kIOHIDOptionsTypeNone))
@@ -151,10 +183,8 @@ class XboxGuideMonitor {
             }
         }
 
-        if let callbackContext {
-            Unmanaged<CallbackContext>.fromOpaque(callbackContext).release()
-            self.callbackContext = nil
-        }
+		callbackContext = nil
+		callbackContextHolder = nil
 
         isStarted = false
     }
@@ -170,33 +200,82 @@ class XboxGuideMonitor {
         if vid == 0x045E {
             connectedMicrosoftPIDs.insert(pid)
 
-            // Determine if usage 13 is Guide or a paddle on this device.
-            // USB-style Elite 2 descriptors have >15 Button Page usages (buttons + paddles),
-            // where usage 13 is a paddle and Guide is at usage 17.
-            // BLE-style descriptors have exactly 15 Button Page usages, where usage 13 IS Guide.
-            let maxButtonUsage = Self.maxButtonPageUsage(for: device)
-            guideLog("  maxButtonUsage=\(maxButtonUsage)")
-            if maxButtonUsage > 15 {
-                let ptr = Unmanaged.passUnretained(device).toOpaque()
-                devicesWhereUsage13IsPaddle.insert(ptr)
-                guideLog("  usage 13 = paddle (USB-style descriptor), Guide at usage 17")
-            }
+			cacheGuideTraits(for: device, shouldLog: true)
         }
     }
 
-    /// Returns the highest Button Page usage on a device by enumerating its HID elements.
-    private static func maxButtonPageUsage(for device: IOHIDDevice) -> UInt32 {
+	private struct GuideTraits {
+		let hasExtendedButtons: Bool
+		let hasACHome: Bool
+	}
+
+	/// Returns the HID guide routing traits for a device by enumerating its elements.
+	private static func guideTraits(for device: IOHIDDevice) -> GuideTraits {
         guard let elements = IOHIDDeviceCopyMatchingElements(device, nil, IOOptionBits(kIOHIDOptionsTypeNone)) as? [IOHIDElement] else {
-            return 0
+			return GuideTraits(hasExtendedButtons: false, hasACHome: false)
         }
         var maxUsage: UInt32 = 0
+		var hasACHome = false
         for element in elements {
-            if IOHIDElementGetUsagePage(element) == kHIDPage_Button {
+			let usagePage = IOHIDElementGetUsagePage(element)
+			if usagePage == kHIDPage_Button {
                 let usage = IOHIDElementGetUsage(element)
                 if usage > maxUsage { maxUsage = usage }
+			} else if usagePage == kHIDPage_Consumer && IOHIDElementGetUsage(element) == 0x0223 {
+				hasACHome = true
+			}
+		}
+		return GuideTraits(hasExtendedButtons: maxUsage > 15, hasACHome: hasACHome)
+	}
+
+	/// Pure guide-event routing policy. Kept testable because Elite 2 HID descriptors vary by firmware.
+	static func isGuideEvent(
+		usagePage: UInt32,
+		usage: UInt32,
+		hasExtendedButtons: Bool,
+		hasACHome: Bool
+	) -> Bool {
+		if usagePage == UInt32(kHIDPage_Consumer) && usage == 0x0223 {
+			return true
+		}
+
+		guard usagePage == UInt32(kHIDPage_Button) else { return false }
+
+		if usage == 13 {
+			return !hasExtendedButtons
+		}
+		if usage == 17 {
+			return !hasACHome
+		}
+		return false
+	}
+
+	@discardableResult
+	private func cacheGuideTraits(for device: IOHIDDevice, shouldLog: Bool = false) -> GuideTraits {
+		let ptr = Unmanaged.passUnretained(device).toOpaque()
+		if !devicesWithKnownGuideTraits.contains(ptr) {
+			let traits = Self.guideTraits(for: device)
+			devicesWithKnownGuideTraits.insert(ptr)
+			if traits.hasExtendedButtons {
+				devicesWithExtendedButtons.insert(ptr)
+			}
+			if traits.hasACHome {
+				devicesWithACHome.insert(ptr)
+			}
+			if shouldLog {
+				guideLog("  hasExtendedButtons=\(traits.hasExtendedButtons) hasACHome=\(traits.hasACHome)")
+				if traits.hasExtendedButtons {
+					guideLog("  usage 13 = paddle (extended button descriptor)")
+				}
+				if traits.hasACHome {
+					guideLog("  Guide = Consumer Page AC Home (0x0223)")
+				}
             }
         }
-        return maxUsage
+		return GuideTraits(
+			hasExtendedButtons: devicesWithExtendedButtons.contains(ptr),
+			hasACHome: devicesWithACHome.contains(ptr)
+		)
     }
 
     fileprivate func deviceRemoved(_ device: IOHIDDevice) {
@@ -206,7 +285,10 @@ class XboxGuideMonitor {
         if vid == 0x045E, let pid = IOHIDDeviceGetProperty(device, kIOHIDProductIDKey as CFString) as? Int {
             connectedMicrosoftPIDs.remove(pid)
         }
-        devicesWhereUsage13IsPaddle.remove(Unmanaged.passUnretained(device).toOpaque())
+		let ptr = Unmanaged.passUnretained(device).toOpaque()
+		devicesWithKnownGuideTraits.remove(ptr)
+		devicesWithExtendedButtons.remove(ptr)
+		devicesWithACHome.remove(ptr)
     }
 
     // MARK: - Input Value Handler
@@ -217,25 +299,17 @@ class XboxGuideMonitor {
         let usage = IOHIDElementGetUsage(element)
         let intValue = IOHIDValueGetIntegerValue(value)
 
-        // Guide button: Button Page
-        // - Usage 17: Guide on USB and Classic BT controllers (>15 buttons on Button Page)
-        // - Usage 13: Guide on BLE controllers (exactly 15 buttons on Button Page)
-        //   BUT on USB-style Elite 2 descriptors, usage 13 is a PADDLE — skip it.
-        if usagePage == kHIDPage_Button {
-            if usage == 17 {
-                let isPressed = intValue != 0
-                DispatchQueue.main.async { [weak self] in
-                    self?.onGuideButtonAction?(isPressed)
-                }
-            } else if usage == 13 {
-                let device = IOHIDElementGetDevice(element)
-                let ptr = Unmanaged.passUnretained(device).toOpaque()
-                if !devicesWhereUsage13IsPaddle.contains(ptr) {
-                    let isPressed = intValue != 0
-                    DispatchQueue.main.async { [weak self] in
-                        self?.onGuideButtonAction?(isPressed)
-                    }
-                }
+		let device = IOHIDElementGetDevice(element)
+		let traits = cacheGuideTraits(for: device)
+		if Self.isGuideEvent(
+			usagePage: usagePage,
+			usage: usage,
+			hasExtendedButtons: traits.hasExtendedButtons,
+			hasACHome: traits.hasACHome
+		) {
+			let isPressed = intValue != 0
+			DispatchQueue.main.async { [weak self] in
+				self?.onGuideButtonAction?(isPressed)
             }
         }
 

--- a/XboxControllerMapper/XboxControllerMapperTests/ControllerServiceCallbackProxyTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ControllerServiceCallbackProxyTests.swift
@@ -92,6 +92,33 @@ final class ControllerServiceCallbackProxyTests: XCTestCase {
         XCTAssertEqual(controllerService.chordWindow, 0.23, accuracy: 0.000_1)
     }
 
+	func testEliteControllerMetadataUsesActiveControllerNames() {
+		XCTAssertTrue(
+			ControllerService.isEliteControllerMetadata(
+				vendorName: "Xbox Elite Wireless Controller",
+				productCategory: "Xbox Controller"
+			)
+		)
+		XCTAssertTrue(
+			ControllerService.isEliteControllerMetadata(
+				vendorName: nil,
+				productCategory: "Xbox Elite Series 2 Controller"
+			)
+		)
+		XCTAssertFalse(
+			ControllerService.isEliteControllerMetadata(
+				vendorName: "Xbox Wireless Controller",
+				productCategory: "Xbox Controller"
+			)
+		)
+	}
+
+	func testGlobalEliteHIDFallbackOnlyAppliesWhenSingleXboxControllerIsActive() {
+		XCTAssertTrue(ControllerService.shouldUseGlobalEliteHIDFallback(connectedXboxControllerCount: 0))
+		XCTAssertTrue(ControllerService.shouldUseGlobalEliteHIDFallback(connectedXboxControllerCount: 1))
+		XCTAssertFalse(ControllerService.shouldUseGlobalEliteHIDFallback(connectedXboxControllerCount: 2))
+	}
+
 	func testGuideMonitorPaddleButtonRequiresRawHIDSource() {
 		controllerService.writeStorage(\.elitePaddleEventSource, .none)
 

--- a/XboxControllerMapper/XboxControllerMapperTests/ControllerServiceCallbackProxyTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ControllerServiceCallbackProxyTests.swift
@@ -91,4 +91,41 @@ final class ControllerServiceCallbackProxyTests: XCTestCase {
         controllerService.chordWindow = 0.23
         XCTAssertEqual(controllerService.chordWindow, 0.23, accuracy: 0.000_1)
     }
+
+	func testGuideMonitorPaddleButtonRequiresRawHIDSource() {
+		controllerService.writeStorage(\.elitePaddleEventSource, .none)
+
+		XCTAssertNil(
+			controllerService.guideMonitorPaddleButton(for: 1, pressed: true),
+			"Raw HID monitor paddle callbacks must be ignored when it does not own Elite paddles."
+		)
+
+		controllerService.writeStorage(\.elitePaddleEventSource, .rawHID)
+
+		XCTAssertEqual(controllerService.guideMonitorPaddleButton(for: 1, pressed: true), .xboxPaddle1)
+		XCTAssertEqual(controllerService.guideMonitorPaddleButton(for: 2, pressed: true), .xboxPaddle2)
+		XCTAssertNil(controllerService.guideMonitorPaddleButton(for: 99, pressed: true))
+	}
+
+	func testRawHIDPaddleSourcesAreDedupedTogether() {
+		controllerService.writeStorage(\.elitePaddleEventSource, .none)
+
+		XCTAssertNil(
+			controllerService.eliteHelperPaddleButton(for: 1, pressed: true),
+			"Helper paddle callbacks must be ignored unless the helper owns Elite paddles."
+		)
+
+		controllerService.writeStorage(\.elitePaddleEventSource, .rawHID)
+
+		XCTAssertEqual(controllerService.guideMonitorPaddleButton(for: 1, pressed: true), .xboxPaddle1)
+		XCTAssertNil(
+			controllerService.eliteHelperPaddleButton(for: 1, pressed: true),
+			"Same-state helper event should be ignored after guide monitor handled the press."
+		)
+		XCTAssertEqual(controllerService.eliteHelperPaddleButton(for: 1, pressed: false), .xboxPaddle1)
+		XCTAssertNil(
+			controllerService.guideMonitorPaddleButton(for: 1, pressed: false),
+			"Same-state guide monitor event should be ignored after helper handled the release."
+		)
+	}
 }

--- a/XboxControllerMapper/XboxControllerMapperTests/XboxGuideMonitorTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/XboxGuideMonitorTests.swift
@@ -1,17 +1,98 @@
 import XCTest
+import IOKit.hid
 @testable import ControllerKeys
 
 final class XboxGuideMonitorTests: XCTestCase {
+
+	// MARK: - Elite 2 guide routing
+
+	func testClassicBluetoothEliteRoutesGuideFromConsumerACHomeOnly() {
+		let buttonPage = UInt32(kHIDPage_Button)
+		let consumerPage = UInt32(kHIDPage_Consumer)
+
+		XCTAssertTrue(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: consumerPage,
+				usage: 0x0223,
+				hasExtendedButtons: true,
+				hasACHome: true
+			),
+			"Classic Bluetooth Elite 2 sends the Xbox button as Consumer AC Home."
+		)
+		XCTAssertFalse(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: buttonPage,
+				usage: 17,
+				hasExtendedButtons: true,
+				hasACHome: true
+			),
+			"Classic Bluetooth Elite 2 mirrors B as Button usage 17; it must not trigger Xbox."
+		)
+		XCTAssertFalse(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: buttonPage,
+				usage: 13,
+				hasExtendedButtons: true,
+				hasACHome: true
+			),
+			"Extended Elite descriptors use Button usage 13 for a paddle, not Guide."
+		)
+	}
+
+	func testBLEEliteRoutesGuideFromButton13() {
+		XCTAssertTrue(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: UInt32(kHIDPage_Button),
+				usage: 13,
+				hasExtendedButtons: false,
+				hasACHome: false
+			)
+		)
+	}
+
+	func testUSBStyleControllersRouteGuideFromButton17() {
+		let buttonPage = UInt32(kHIDPage_Button)
+
+		XCTAssertTrue(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: buttonPage,
+				usage: 17,
+				hasExtendedButtons: true,
+				hasACHome: false
+			)
+		)
+		XCTAssertFalse(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: buttonPage,
+				usage: 13,
+				hasExtendedButtons: true,
+				hasACHome: false
+			)
+		)
+	}
+
+	func testPaddleConsumerUsageIsNotGuide() {
+		XCTAssertFalse(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: UInt32(kHIDPage_Consumer),
+				usage: 0x81,
+				hasExtendedButtons: true,
+				hasACHome: true
+			)
+		)
+	}
 
     // MARK: - CallbackContext weak reference safety
 
     func testCallbackContextWeakReference() {
         // The core safety property: when the monitor is deallocated,
         // the CallbackContext's weak reference becomes nil (no dangling pointer).
-        var monitor: XboxGuideMonitor? = XboxGuideMonitor()
+		var monitor: XboxGuideMonitor? = XboxGuideMonitor(enableHardwareMonitoring: false)
+		monitor?.prepareCallbackContextForTesting()
         weak var weakMonitor = monitor
 
         XCTAssertNotNil(weakMonitor, "Monitor should be alive")
+		XCTAssertEqual(monitor?.hasCallbackContextForTesting, true)
 
         monitor = nil
 
@@ -21,18 +102,22 @@ final class XboxGuideMonitorTests: XCTestCase {
     // MARK: - stop() releases callback context
 
     func testStopReleasesCallbackContext() {
-        let monitor = XboxGuideMonitor()
+		let monitor = XboxGuideMonitor(enableHardwareMonitoring: false)
+		monitor.prepareCallbackContextForTesting()
         XCTAssertTrue(monitor.isStarted, "Monitor should be started after init")
+		XCTAssertTrue(monitor.hasCallbackContextForTesting, "Monitor should have an owned callback context")
 
         monitor.stop()
 
         XCTAssertFalse(monitor.isStarted, "Monitor should not be started after stop()")
+		XCTAssertFalse(monitor.hasCallbackContextForTesting, "stop() should release the callback context")
     }
 
     // MARK: - Double stop does not crash
 
     func testDoubleStopDoesNotCrash() {
-        let monitor = XboxGuideMonitor()
+		let monitor = XboxGuideMonitor(enableHardwareMonitoring: false)
+		monitor.prepareCallbackContextForTesting()
         monitor.stop()
         monitor.stop() // Must not double-release or crash
         XCTAssertFalse(monitor.isStarted)
@@ -41,7 +126,7 @@ final class XboxGuideMonitorTests: XCTestCase {
     // MARK: - Double start is a no-op
 
     func testDoubleStartDoesNotLeak() {
-        let monitor = XboxGuideMonitor()
+		let monitor = XboxGuideMonitor(enableHardwareMonitoring: false)
         XCTAssertTrue(monitor.isStarted)
 
         // Second start should be guarded by isStarted flag
@@ -56,8 +141,10 @@ final class XboxGuideMonitorTests: XCTestCase {
     // MARK: - deinit calls stop
 
     func testDeinitCallsStop() {
-        var monitor: XboxGuideMonitor? = XboxGuideMonitor()
+		var monitor: XboxGuideMonitor? = XboxGuideMonitor(enableHardwareMonitoring: false)
+		monitor?.prepareCallbackContextForTesting()
         XCTAssertTrue(monitor!.isStarted)
+		XCTAssertTrue(monitor!.hasCallbackContextForTesting)
 
         // When the monitor goes out of scope, deinit should call stop()
         // without crashing. If stop() wasn't called, the retained
@@ -69,7 +156,7 @@ final class XboxGuideMonitorTests: XCTestCase {
     // MARK: - Start after stop restarts correctly
 
     func testStartAfterStopRestartsCorrectly() {
-        let monitor = XboxGuideMonitor()
+		let monitor = XboxGuideMonitor(enableHardwareMonitoring: false)
         XCTAssertTrue(monitor.isStarted)
 
         monitor.stop()
@@ -81,4 +168,59 @@ final class XboxGuideMonitorTests: XCTestCase {
         monitor.stop()
         XCTAssertFalse(monitor.isStarted)
     }
+}
+
+@MainActor
+final class EliteControllerInputPolicyTests: XCTestCase {
+
+	func testPaddleEventSourceIsNoneWhenGameControllerExposesPaddles() {
+		XCTAssertEqual(
+			EliteControllerInputPolicy.paddleEventSource(gameControllerHasPaddles: true),
+			.none
+		)
+	}
+
+	func testPaddleEventSourceIsRawHIDWhenGameControllerDoesNotExposePaddles() {
+		XCTAssertEqual(
+			EliteControllerInputPolicy.paddleEventSource(gameControllerHasPaddles: false),
+			.rawHID
+		)
+	}
+
+	func testHelperPaddleOwnershipComesFromRawHIDSource() {
+		XCTAssertFalse(EliteControllerInputPolicy.helperHandlesPaddles(paddleEventSource: .none))
+		XCTAssertTrue(EliteControllerInputPolicy.helperHandlesPaddles(paddleEventSource: .rawHID))
+	}
+
+	func testHelperArgumentsUseGuideOnlyWhenHelperDoesNotOwnPaddles() {
+		XCTAssertEqual(
+			EliteControllerInputPolicy.helperArguments(paddleEventSource: .none),
+			["--guide-only"]
+		)
+		XCTAssertEqual(
+			EliteControllerInputPolicy.helperArguments(paddleEventSource: .rawHID),
+			[]
+		)
+	}
+
+	func testHelperRestartsOnlyWhenRequestedPaddleModeChanges() {
+		XCTAssertFalse(
+			EliteControllerInputPolicy.helperNeedsRestart(
+				currentHandlePaddles: true,
+				requestedHandlePaddles: true
+			)
+		)
+		XCTAssertTrue(
+			EliteControllerInputPolicy.helperNeedsRestart(
+				currentHandlePaddles: true,
+				requestedHandlePaddles: false
+			)
+		)
+		XCTAssertTrue(
+			EliteControllerInputPolicy.helperNeedsRestart(
+				currentHandlePaddles: nil,
+				requestedHandlePaddles: true
+			)
+		)
+	}
 }

--- a/XboxControllerMapper/XboxControllerMapperTests/XboxGuideMonitorTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/XboxGuideMonitorTests.swift
@@ -71,6 +71,40 @@ final class XboxGuideMonitorTests: XCTestCase {
 		)
 	}
 
+	func testEliteSessionACHomeSuppressesButton17AcrossInterfaces() {
+		let traits = XboxGuideMonitor.effectiveGuideTraits(
+			deviceTraits: XboxGuideMonitor.GuideTraits(hasExtendedButtons: true, hasACHome: false),
+			eliteSessionTraits: XboxGuideMonitor.GuideTraits(hasExtendedButtons: false, hasACHome: true)
+		)
+
+		XCTAssertFalse(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: UInt32(kHIDPage_Button),
+				usage: 17,
+				hasExtendedButtons: traits.hasExtendedButtons,
+				hasACHome: traits.hasACHome
+			),
+			"Classic Bluetooth can expose Guide on one Consumer interface while B mirrors as Button 17 on another."
+		)
+	}
+
+	func testEliteSessionExtendedButtonsSuppressButton13AcrossInterfaces() {
+		let traits = XboxGuideMonitor.effectiveGuideTraits(
+			deviceTraits: .none,
+			eliteSessionTraits: XboxGuideMonitor.GuideTraits(hasExtendedButtons: true, hasACHome: false)
+		)
+
+		XCTAssertFalse(
+			XboxGuideMonitor.isGuideEvent(
+				usagePage: UInt32(kHIDPage_Button),
+				usage: 13,
+				hasExtendedButtons: traits.hasExtendedButtons,
+				hasACHome: traits.hasACHome
+			),
+			"Extended Elite descriptors use Button 13 for paddle input even if that trait was discovered on another interface."
+		)
+	}
+
 	func testPaddleConsumerUsageIsNotGuide() {
 		XCTAssertFalse(
 			XboxGuideMonitor.isGuideEvent(


### PR DESCRIPTION
## Summary
- restore Elite 2 paddle handling when GameController does not expose paddles
- keep GameController-owned paddles authoritative when available, with helper in guide-only mode
- harden Guide routing across split Elite HID interfaces to avoid Button 13/17 crosstalk
- sign the bundled Elite helper during local install so macOS does not kill it

## Verification
- git diff --check
- swiftc -typecheck Helpers/XboxEliteHelper.swift
- focused Xcode tests for XboxGuideMonitor, ControllerServiceCallbackProxy, EliteControllerInputPolicy
- make install BUILD_FROM_SOURCE=1
- codesign verification for app and helper

## Notes
- Tested locally on Kevin's Elite 2 PID 0x0B22.
- Customer log path has GameController-exposed paddles plus Consumer AC Home Guide; this PR keeps GC paddles authoritative and suppresses mirrored Button 17/13 crosstalk for Elite sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic detection of Xbox Elite controller variants for more accurate paddle and guide handling
  * New "guide-only" mode to control paddle JSON output

* **Bug Fixes**
  * Improved routing and suppression of guide vs paddle events across interfaces
  * Better paddle event deduplication and ownership handling

* **Tests**
  * Expanded test coverage for Elite detection, paddle routing, and callback lifecycle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSEvent/xbox-controller-mapper/pull/16)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->