### PR TITLE
feat: add window background opacity setting

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentView.swift
@@ -465,7 +465,7 @@ struct LegendItem: View {
 
 enum WindowBackgroundDefaults {
     static let opacityKey = "windowBackgroundOpacity"
-    static let defaultOpacity: Double = 0.85
+    static let defaultOpacity: Double = 0.5
 }
 
 /// A view that wraps NSVisualEffectView for SwiftUI

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentView.swift
@@ -28,6 +28,10 @@ struct ContentView: View {
     @State private var editingGestureType: MotionGestureType?
     @State private var scrollKeyMonitor: Any?
     @AppStorage(MainWindowSection.hiddenDefaultsKey) private var hiddenSectionTags = ""
+    @AppStorage(WindowBackgroundDefaults.opacityKey) private var windowBackgroundOpacity: Double = WindowBackgroundDefaults.defaultOpacity
+    private var clampedWindowBackgroundOpacity: Double {
+        min(max(windowBackgroundOpacity, 0.0), 1.0)
+    }
     private var actionFeedbackEnabled: Binding<Bool> {
         Binding(
             get: { ActionFeedbackIndicator.isEnabled },
@@ -133,10 +137,16 @@ struct ContentView: View {
         }
         .frame(minWidth: 900, minHeight: 650)
         // Global Glass Background
+        //
+        // NSVisualEffectView with `.behindWindow` blending samples desktop/app
+        // content behind the window. To let the user dampen how much of that
+        // bleeds through, layer a dark tint ON TOP of the visual effect — its
+        // opacity is user-configurable. 0.0 = pure liquid glass, 1.0 = fully
+        // opaque dark background.
         .background(
             ZStack {
-                Color.black.opacity(0.92) // Dark tint
                 GlassVisualEffectView(material: .hudWindow, blendingMode: .behindWindow)
+                Color.black.opacity(clampedWindowBackgroundOpacity)
             }
             .ignoresSafeArea()
         )
@@ -452,6 +462,11 @@ struct LegendItem: View {
 }
 
 // MARK: - Glass Aesthetic Components
+
+enum WindowBackgroundDefaults {
+    static let opacityKey = "windowBackgroundOpacity"
+    static let defaultOpacity: Double = 0.85
+}
 
 /// A view that wraps NSVisualEffectView for SwiftUI
 struct GlassVisualEffectView: NSViewRepresentable {

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
@@ -1126,6 +1126,7 @@ struct SettingsSheet: View {
     @AppStorage(ButtonMappingsTabSection.hiddenDefaultsKey) private var hiddenButtonSectionTags = ""
     @AppStorage("universalControlRelayHost") private var relayRemoteHost = "kmacstudio"
     @AppStorage("universalControlRelayPort") private var relayRemotePort = 38383
+    @AppStorage(WindowBackgroundDefaults.opacityKey) private var windowBackgroundOpacity: Double = WindowBackgroundDefaults.defaultOpacity
 
     @State private var isRefreshingDatabase = false
     @State private var databaseStatus: String?
@@ -1182,6 +1183,32 @@ struct SettingsSheet: View {
                         // icon appears immediately even if no window is key.
                         NSApp.activate(ignoringOtherApps: true)
                     }
+                }
+
+                Section {
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("Window Background Opacity")
+                            Spacer()
+                            Text("\(Int(windowBackgroundOpacity * 100))%")
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                        Slider(value: $windowBackgroundOpacity, in: 0.0...1.0)
+                        HStack {
+                            Text("How much the desktop and other apps bleed through the window. Higher is more opaque.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                            Spacer()
+                            Button("Reset") {
+                                windowBackgroundOpacity = WindowBackgroundDefaults.defaultOpacity
+                            }
+                            .controlSize(.small)
+                        }
+                    }
+                } header: {
+                    Text("Appearance")
                 }
 
                 Section {


### PR DESCRIPTION
## Summary

Closes #15.

- Adds an **Appearance** section in Settings with a slider for the main window's background opacity (0% – 100%) plus a Reset button.
- Defaults to **85%** — more opaque than before, so the liquid-glass effect picks up much less color from underlying apps.
- Setting is persisted via `@AppStorage("windowBackgroundOpacity")`.

## Why this works

The previous `Color.black.opacity(0.92)` tint was placed *behind* `GlassVisualEffectView` in the ZStack, so it was effectively invisible. Moved it on top so the opacity actually controls how much underlying content bleeds through.

- `0.0` = pure liquid glass (current pre-fix behavior)
- `0.85` = new default (mostly opaque, still some glass)
- `1.0` = fully opaque dark background

## Test plan

- [x] `make build BUILD_FROM_SOURCE=1` succeeds
- [ ] Open Settings → Appearance, drag slider, verify window background opacity changes live
- [ ] Verify default on fresh install is 85%
- [ ] Verify Reset returns to 85%
- [ ] Verify setting persists across app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Window background opacity is now adjustable in the new Appearance settings section.
  * Customize window transparency with a slider (0–100%).
  * Value is shown as a percentage and persists automatically between sessions.
  * Quick Reset button restores the default opacity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSEvent/xbox-controller-mapper/pull/17)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->