### PR TITLE
feat: per-layer stick mode override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Per-layer stick mode override**: Each layer can now override the **Mouse / Scroll / WASD / Custom** mode of either stick, independent of the profile-level default. Edit a layer in the Buttons tab and pick a mode from the inline dropdown on the stick — that choice applies only while the layer is active; release the activator and the base mode resumes. A new **Inherit from Base** menu item drops the override; inherited values render in italic so it's obvious which stick is layer-scoped vs. profile-scoped. Addresses [#14](https://github.com/NSEvent/xbox-controller-mapper/issues/14) — previously the inline mode dropdown silently wrote to profile-level state regardless of which layer was being edited, so customers swapping `Mouse`/`Scroll` per layer found the change leaking to all layers. Profile-level mode still lives in the Joysticks tab; the rest of the joystick tuning (sensitivity, deadzone, acceleration) stays profile-level for now and can move per-layer later if anyone asks.
+
+- **Inert direction-binding warning**: When a layer (or the base) has custom stick-direction button mappings but the effective stick mode for that side isn't Custom — i.e. the bindings won't fire — a small orange warning appears next to the stick's mode dropdown explaining that switching to Custom is required. Prevents a silent-no-op confusion that's easy to land in after toggling mode away from Custom.
+
 ## [1.8.0] - 2026-05-13
 
 ### Added

--- a/XboxControllerMapper/XboxControllerMapper/Models/Layer.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Models/Layer.swift
@@ -50,24 +50,35 @@ struct Layer: Codable, Identifiable, Equatable {
     /// Optional LED settings applied when this layer is active (nil = inherit profile settings)
     var dualSenseLEDSettings: DualSenseLEDSettings?
 
+    /// Per-stick-mode overrides applied when this layer is active.
+    /// nil = inherit the profile-level `JoystickSettings.leftStickMode` / `rightStickMode`.
+    /// Other joystick tuning (sensitivity, deadzone, acceleration) stays profile-level.
+    var leftStickModeOverride: StickMode?
+    var rightStickModeOverride: StickMode?
+
     init(
         id: UUID = UUID(),
         name: String,
         activatorButton: ControllerButton? = nil,
         buttonMappings: [ControllerButton: KeyMapping] = [:],
-        dualSenseLEDSettings: DualSenseLEDSettings? = nil
+        dualSenseLEDSettings: DualSenseLEDSettings? = nil,
+        leftStickModeOverride: StickMode? = nil,
+        rightStickModeOverride: StickMode? = nil
     ) {
         self.id = id
         self.name = name
         self.activatorButton = activatorButton
         self.buttonMappings = buttonMappings
         self.dualSenseLEDSettings = dualSenseLEDSettings
+        self.leftStickModeOverride = leftStickModeOverride
+        self.rightStickModeOverride = rightStickModeOverride
     }
 
     // MARK: - Custom Codable
 
     private enum CodingKeys: String, CodingKey {
         case id, name, activatorButton, buttonMappings, dualSenseLEDSettings
+        case leftStickModeOverride, rightStickModeOverride
     }
 
     init(from decoder: Decoder) throws {
@@ -86,6 +97,8 @@ struct Layer: Codable, Identifiable, Equatable {
         })
 
         dualSenseLEDSettings = try container.decodeIfPresent(DualSenseLEDSettings.self, forKey: .dualSenseLEDSettings)
+        leftStickModeOverride = try container.decodeIfPresent(StickMode.self, forKey: .leftStickModeOverride)
+        rightStickModeOverride = try container.decodeIfPresent(StickMode.self, forKey: .rightStickModeOverride)
     }
 
     func encode(to encoder: Encoder) throws {
@@ -100,5 +113,7 @@ struct Layer: Codable, Identifiable, Equatable {
         try container.encode(stringKeyedMappings, forKey: .buttonMappings)
 
         try container.encodeIfPresent(dualSenseLEDSettings, forKey: .dualSenseLEDSettings)
+        try container.encodeIfPresent(leftStickModeOverride, forKey: .leftStickModeOverride)
+        try container.encodeIfPresent(rightStickModeOverride, forKey: .rightStickModeOverride)
     }
 }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/JoystickHandler.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/JoystickHandler.swift
@@ -172,6 +172,15 @@ extension MappingEngine {
             return
         }
 
+        // Resolve effective per-side modes: active layer override (if any) wins over profile default.
+        // Lock is held for the whole function, so reading state.activeLayerIds + state.activeProfile here is safe.
+        let activeLayer: Layer? = {
+            guard let layerId = state.activeLayerIds.last else { return nil }
+            return state.activeProfile?.layers.first(where: { $0.id == layerId })
+        }()
+        let effectiveLeftMode = activeLayer?.leftStickModeOverride ?? settings.leftStickMode
+        let effectiveRightMode = activeLayer?.rightStickModeOverride ?? settings.rightStickMode
+
         let leftInput = JoystickStickInput(
             stick: leftStick,
             side: .left,
@@ -180,7 +189,7 @@ extension MappingEngine {
             now: now,
             hasMotion: controllerSnapshot.hasMotion
         )
-        settings.leftStickMode.strategy.process(leftInput, on: self)
+        effectiveLeftMode.strategy.process(leftInput, on: self)
 
         let rightStick = controllerSnapshot.rightStick
 
@@ -198,7 +207,7 @@ extension MappingEngine {
                 now: now,
                 hasMotion: controllerSnapshot.hasMotion
             )
-            settings.rightStickMode.strategy.process(rightInput, on: self)
+            effectiveRightMode.strategy.process(rightInput, on: self)
         }
     }
 

--- a/XboxControllerMapper/XboxControllerMapper/Services/Profile/ProfileManager.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Profile/ProfileManager.swift
@@ -301,6 +301,35 @@ class ProfileManager: ObservableObject {
         updateProfile(targetProfile)
     }
 
+    /// Sets the stick mode for one side at the given scope.
+    /// - Parameter layerId: When nil, writes the profile-level default (i.e. `JoystickSettings.leftStickMode`/`rightStickMode`).
+    ///   When non-nil, writes that layer's per-side override. Pass `mode = nil` together with a layer id to clear the override
+    ///   so the layer falls back to the profile default.
+    func setStickMode(_ mode: StickMode?, side: JoystickSide, layerId: UUID?, in profile: Profile? = nil) {
+        guard var targetProfile = profile ?? activeProfile else { return }
+
+        if let layerId {
+            guard let layerIndex = targetProfile.layers.firstIndex(where: { $0.id == layerId }) else { return }
+            switch side {
+            case .left:
+                targetProfile.layers[layerIndex].leftStickModeOverride = mode
+            case .right:
+                targetProfile.layers[layerIndex].rightStickModeOverride = mode
+            }
+        } else {
+            // Profile-level write: a nil mode is meaningless here (the profile always has a concrete mode),
+            // so callers must pass a real StickMode for layer-id-less writes.
+            guard let mode else { return }
+            switch side {
+            case .left:
+                targetProfile.joystickSettings.leftStickMode = mode
+            case .right:
+                targetProfile.joystickSettings.rightStickMode = mode
+            }
+        }
+        updateProfile(targetProfile)
+    }
+
     // MARK: - DualSense LED Settings
 
     func updateDualSenseLEDSettings(_ settings: DualSenseLEDSettings, in profile: Profile? = nil) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ControllerVisualView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ControllerVisualView.swift
@@ -591,6 +591,19 @@ struct ControllerVisualView: View {
             }
             .padding(.horizontal, 4)
 
+            if hasOrphanedStickDirectionMappings(side: side) {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.system(size: 9))
+                        .foregroundStyle(.orange)
+                    Text("Direction bindings inactive — switch mode to Custom to use them.")
+                        .font(.system(size: 10))
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.horizontal, 4)
+            }
+
             if mode.exposesJoystickDirections {
                 directionClusterGrid(
                     up: buttons.contains(ControllerButton.joystickDirectionButton(side: side, direction: .up))
@@ -625,7 +638,26 @@ struct ControllerVisualView: View {
         )
     }
 
-    private func stickMode(side: JoystickSide) -> StickMode {
+    /// Returns true when the current editing scope (layer if selected, else profile) has direction
+    /// button mappings for this side, but the effective stick mode won't dispatch them at runtime.
+    /// Used to surface a small "these bindings won't fire" hint next to the stick mode picker so
+    /// users don't get silently confused after switching mode away from Custom.
+    private func hasOrphanedStickDirectionMappings(side: JoystickSide) -> Bool {
+        guard !stickMode(side: side).exposesJoystickDirections else { return false }
+        let directionButtons = Set(ControllerButton.joystickDirectionButtons(side: side))
+
+        // Editing a layer: check that layer's own mappings (not the base).
+        // Editing the base: check the profile-level mappings.
+        let scopedMappings: [ControllerButton: KeyMapping]
+        if let layer = selectedLayer {
+            scopedMappings = layer.buttonMappings
+        } else {
+            scopedMappings = profileManager.activeProfile?.buttonMappings ?? [:]
+        }
+        return scopedMappings.keys.contains { directionButtons.contains($0) }
+    }
+
+    private func profileStickMode(side: JoystickSide) -> StickMode {
         switch side {
         case .left:
             return joystickSettings.leftStickMode
@@ -634,27 +666,64 @@ struct ControllerVisualView: View {
         }
     }
 
-    private func setStickMode(_ mode: StickMode, side: JoystickSide) {
-        guard mode.isVisibleInUI else { return }
-        var settings = joystickSettings
+    private func layerStickModeOverride(side: JoystickSide) -> StickMode? {
+        guard let layer = selectedLayer else { return nil }
         switch side {
         case .left:
-            settings.leftStickMode = mode
+            return layer.leftStickModeOverride
         case .right:
-            settings.rightStickMode = mode
+            return layer.rightStickModeOverride
         }
-        profileManager.updateJoystickSettings(settings)
+    }
+
+    /// Effective mode resolved at the current editing scope: layer override (if any) → profile default.
+    /// Mirrors `JoystickHandler`'s runtime resolution so the picker label and the actual behavior stay aligned.
+    private func stickMode(side: JoystickSide) -> StickMode {
+        layerStickModeOverride(side: side) ?? profileStickMode(side: side)
+    }
+
+    /// True when editing a layer AND that layer has no override for this side, so the displayed
+    /// mode is inherited from the base profile. Used to subtly italicize the picker label.
+    private func isStickModeInherited(side: JoystickSide) -> Bool {
+        selectedLayerId != nil && layerStickModeOverride(side: side) == nil
+    }
+
+    private func setStickMode(_ mode: StickMode, side: JoystickSide) {
+        guard mode.isVisibleInUI else { return }
+        profileManager.setStickMode(mode, side: side, layerId: selectedLayerId)
+    }
+
+    private func clearStickModeOverride(side: JoystickSide) {
+        guard let layerId = selectedLayerId else { return }
+        profileManager.setStickMode(nil, side: side, layerId: layerId)
     }
 
     private func stickModeMenu(side: JoystickSide) -> some View {
         let selectedMode = stickMode(side: side)
+        let inherited = isStickModeInherited(side: side)
+        let editingLayer = selectedLayerId != nil
 
         return Menu {
+            if editingLayer {
+                Button {
+                    clearStickModeOverride(side: side)
+                } label: {
+                    if inherited {
+                        Label("Inherit from Base", systemImage: "checkmark")
+                    } else {
+                        Text("Inherit from Base")
+                    }
+                }
+                Divider()
+            }
             ForEach(StickMode.visibleModes, id: \.self) { mode in
                 Button {
                     setStickMode(mode, side: side)
                 } label: {
-                    if mode == selectedMode {
+                    // Only show a checkmark next to the explicitly-selected mode. If the layer
+                    // is inheriting, the checkmark sits next to "Inherit from Base" instead, so
+                    // the user can distinguish "explicitly set to Mouse" from "inheriting Mouse."
+                    if mode == selectedMode && !inherited {
                         Label {
                             Text(LocalizedStringKey(mode.displayName))
                         } icon: {
@@ -669,6 +738,7 @@ struct ControllerVisualView: View {
             HStack(spacing: 4) {
                 Text(LocalizedStringKey(selectedMode.displayName))
                     .font(.system(size: 9, weight: .heavy, design: .rounded))
+                    .italic(inherited)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
                 Image(systemName: "chevron.up.chevron.down")

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ControllerVisualView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ControllerVisualView.swift
@@ -584,10 +584,10 @@ struct ControllerVisualView: View {
                     .foregroundColor(.secondary)
 
                 Spacer(minLength: 4)
-                stickModeMenu(side: side)
                 if mode.exposesJoystickDirections {
                     stickPresetMenu(side: side)
                 }
+                stickModeMenu(side: side)
             }
             .padding(.horizontal, 4)
 

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
@@ -22,6 +22,9 @@ struct JoystickSettingsView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                Text("Profile default. Override per-layer from the stick's dropdown in the Buttons tab.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
                 if settings.leftStickMode == .mouse {
                     SliderRow(
@@ -181,6 +184,9 @@ struct JoystickSettingsView: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                Text("Profile default. Override per-layer from the stick's dropdown in the Buttons tab.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
 
                 if settings.rightStickMode == .mouse {
                     SliderRow(

--- a/XboxControllerMapper/XboxControllerMapperTests/LayerStickModeOverrideTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/LayerStickModeOverrideTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import ControllerKeys
+
+@MainActor
+final class LayerStickModeOverrideTests: XCTestCase {
+    private var profileManager: ProfileManager!
+    private var testConfigDirectory: URL!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        testConfigDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("controllerkeys-layer-stick-\(UUID().uuidString)", isDirectory: true)
+        profileManager = ProfileManager(configDirectoryOverride: testConfigDirectory)
+    }
+
+    override func tearDown() async throws {
+        profileManager = nil
+        testConfigDirectory = nil
+        try await super.tearDown()
+    }
+
+    /// Profile-level write (nil layerId) updates JoystickSettings, not any layer.
+    func testSetStickMode_profileScope_updatesJoystickSettings() throws {
+        let layer = try XCTUnwrap(profileManager.createLayer(name: "L1", activatorButton: .leftBumper))
+
+        profileManager.setStickMode(.scroll, side: .left, layerId: nil)
+
+        let active = try XCTUnwrap(profileManager.activeProfile)
+        XCTAssertEqual(active.joystickSettings.leftStickMode, .scroll)
+        let stored = try XCTUnwrap(active.layers.first(where: { $0.id == layer.id }))
+        XCTAssertNil(stored.leftStickModeOverride, "Profile-level write must not touch layer overrides.")
+    }
+
+    /// Per-layer write sets the override on that layer only.
+    func testSetStickMode_layerScope_setsOverride() throws {
+        let layer = try XCTUnwrap(profileManager.createLayer(name: "L1", activatorButton: .leftBumper))
+        let baseLeftMode = profileManager.activeProfile?.joystickSettings.leftStickMode
+
+        profileManager.setStickMode(.scroll, side: .left, layerId: layer.id)
+
+        let active = try XCTUnwrap(profileManager.activeProfile)
+        let stored = try XCTUnwrap(active.layers.first(where: { $0.id == layer.id }))
+        XCTAssertEqual(stored.leftStickModeOverride, .scroll)
+        XCTAssertEqual(active.joystickSettings.leftStickMode, baseLeftMode,
+                       "Layer-scoped write must not mutate profile-level mode.")
+    }
+
+    /// Clearing a layer override (nil mode + non-nil layerId) drops it back to inheriting.
+    func testSetStickMode_layerScope_clearOverrideWithNilMode() throws {
+        let layer = try XCTUnwrap(profileManager.createLayer(name: "L1", activatorButton: .leftBumper))
+        profileManager.setStickMode(.scroll, side: .right, layerId: layer.id)
+        XCTAssertEqual(profileManager.activeProfile?.layers.first?.rightStickModeOverride, .scroll)
+
+        profileManager.setStickMode(nil, side: .right, layerId: layer.id)
+
+        XCTAssertNil(profileManager.activeProfile?.layers.first?.rightStickModeOverride)
+    }
+
+    /// Profile-level write with nil mode is a no-op (the profile must always have a concrete mode).
+    func testSetStickMode_profileScope_nilModeIsNoop() throws {
+        let initial = profileManager.activeProfile?.joystickSettings.leftStickMode
+
+        profileManager.setStickMode(nil, side: .left, layerId: nil)
+
+        XCTAssertEqual(profileManager.activeProfile?.joystickSettings.leftStickMode, initial)
+    }
+
+    /// Two layers can independently override the same side.
+    func testSetStickMode_layerScope_independentAcrossLayers() throws {
+        let layerA = try XCTUnwrap(profileManager.createLayer(name: "A", activatorButton: .leftBumper))
+        let layerB = try XCTUnwrap(profileManager.createLayer(name: "B", activatorButton: .rightBumper))
+
+        profileManager.setStickMode(.scroll, side: .left, layerId: layerA.id)
+        profileManager.setStickMode(.mouse, side: .left, layerId: layerB.id)
+
+        let stored = try XCTUnwrap(profileManager.activeProfile?.layers)
+        let a = try XCTUnwrap(stored.first(where: { $0.id == layerA.id }))
+        let b = try XCTUnwrap(stored.first(where: { $0.id == layerB.id }))
+        XCTAssertEqual(a.leftStickModeOverride, .scroll)
+        XCTAssertEqual(b.leftStickModeOverride, .mouse)
+    }
+
+    /// The override field survives a Codable round-trip (matters for config persistence).
+    func testLayer_codableRoundTripPreservesOverrides() throws {
+        var layer = Layer(name: "RT", activatorButton: .leftBumper)
+        layer.leftStickModeOverride = .scroll
+        layer.rightStickModeOverride = .mouse
+
+        let data = try JSONEncoder().encode(layer)
+        let decoded = try JSONDecoder().decode(Layer.self, from: data)
+
+        XCTAssertEqual(decoded.leftStickModeOverride, .scroll)
+        XCTAssertEqual(decoded.rightStickModeOverride, .mouse)
+    }
+
+    /// Existing configs without the override fields decode with nil overrides (no migration needed).
+    func testLayer_backwardCompatibleDecode_missingFieldsAreNil() throws {
+        let json = """
+        {
+            "id": "\(UUID().uuidString)",
+            "name": "Legacy",
+            "buttonMappings": {}
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(Layer.self, from: json)
+
+        XCTAssertNil(decoded.leftStickModeOverride)
+        XCTAssertNil(decoded.rightStickModeOverride)
+    }
+}


### PR DESCRIPTION
## Summary

Closes #14.

Each layer can now override the L/R stick mode independently of the profile-level default. The inline mode dropdown in the Buttons tab is now layer-scoped when a layer is being edited; previously it silently wrote to profile-level state regardless, which is exactly the bug salmanuc hit on v1.8.0 ("changing the mode for layer 2 changes it for all layers").

## Changes

**Data model** (\`Layer.swift\`)
- New optional fields: \`leftStickModeOverride: StickMode?\`, \`rightStickModeOverride: StickMode?\`.
- Codable: \`decodeIfPresent\` with nil default, \`encodeIfPresent\` to avoid bloating existing configs. Backward-compatible — old configs open with all layers inheriting, current behavior preserved.

**Mutation API** (\`ProfileManager.setStickMode\`)
- \`func setStickMode(_ mode: StickMode?, side: JoystickSide, layerId: UUID?, in profile:)\`
- \`layerId == nil\` → writes profile-level (\`mode\` required).
- \`layerId != nil\` + \`mode != nil\` → sets layer override.
- \`layerId != nil\` + \`mode == nil\` → clears layer override (inherit).

**Runtime resolution** (\`JoystickHandler\`)
- At each 120 Hz poll, resolves \`activeLayer?.leftStickModeOverride ?? settings.leftStickMode\` (same for right) under the engine lock. Dispatches the correct strategy. No caching — picker edits take effect on the next poll.

**UI** (\`ControllerVisualView\`)
- Inline mode dropdown on each stick is now layer-aware. Reads effective mode and writes via \`setStickMode(_:side:layerId:)\` with the current \`selectedLayerId\`.
- When editing a layer, a new **Inherit from Base** menu item at the top of the dropdown clears the override.
- Inherited values render italicized so layer-scoped vs profile-scoped is visually obvious at a glance.
- Inline orange warning surfaces when the editing scope has stick-direction button mappings but the effective mode isn't Custom — i.e. those bindings won't fire at runtime. Catches the silent-no-op confusion you'd otherwise hit after switching mode away from Custom.

**Joysticks tab caption** (\`SettingsViews.JoystickSettingsView\`)
- Small caption under each mode picker: "Profile default. Override per-layer from the stick's dropdown in the Buttons tab." So users don't get whiplash seeing the Joysticks tab show the base mode while their layer override is in effect.

## Tests

New \`LayerStickModeOverrideTests.swift\` covers:
- Profile-level write hits \`JoystickSettings\`, not layer overrides.
- Layer-scoped write sets only that layer's override, leaves profile alone.
- \`mode == nil\` + non-nil \`layerId\` clears the override.
- \`mode == nil\` + nil \`layerId\` is a no-op (profile must always have a concrete mode).
- Two layers can carry independent overrides for the same side.
- Codable round-trip preserves override values.
- Legacy configs without the new fields decode with nil overrides.

All 7 pass locally.

## Test plan

- [x] \`make build BUILD_FROM_SOURCE=1\` succeeds
- [x] \`xcodebuild test -only-testing:LayerStickModeOverrideTests\` — all 7 pass
- [ ] Edit a layer in the Buttons tab, change L stick from Mouse → Scroll. Switch to base, verify base is still Mouse.
- [ ] Activate the layer (hold its activator), wiggle the L stick, confirm it scrolls. Release activator, confirm it returns to mousing.
- [ ] Open the dropdown on a layer, pick "Inherit from Base", confirm the label goes italic and the override is cleared.
- [ ] Set base mode to Custom with WASD preset, then on layer 2 override to Mouse. Verify the orange "Direction bindings inactive" warning shows on layer 2's stick.
- [ ] Verify existing 1.8.0 configs open without errors (no migration needed).

## Notes

- **Mode-swap mid-motion**: releasing a layer activator while a stick is mid-deflection cleanly swaps strategies on the next poll. Cursor may "jump" to the new strategy's interpretation of the held deflection. Acceptable; revisit if anyone complains.
- **Joysticks tab is still profile-scoped**: per-layer is only edited via the inline picker. Picked option (b) from the review — minimum surface area, exposes the data model directly via caption.
- Per-field nullable overrides (not full-struct override). Diverges from \`Layer.dualSenseLEDSettings: DualSenseLEDSettings?\` precedent on purpose — joystick settings struct is large and only mode is being asked for per-layer today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-layer stick mode overrides—each layer can override left and right stick modes independently, with an "Inherit from Base" option.

* **UI Improvements**
  * Direction-binding warning—orange alert when direction bindings exist but the effective stick mode won’t process them.
  * Inherited stick mode labels shown in italics; added guidance text about profile defaults and per-layer overrides.

* **Tests**
  * Added test coverage for per-layer overrides, clearing overrides, and encoding/decoding behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSEvent/xbox-controller-mapper/pull/20)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->