### PR TITLE
fix: recover stale Elite Guide presses

### DIFF
--- a/Helpers/XboxEliteHelper.swift
+++ b/Helpers/XboxEliteHelper.swift
@@ -33,7 +33,7 @@ import IOKit.hid
 // MARK: - State
 
 let shouldEmitPaddles = !CommandLine.arguments.contains("--guide-only")
-let guideStalePressRecoveryInterval: TimeInterval = 2.0
+let guideDuplicateForwardInterval: TimeInterval = 2.0
 var guidePressed = false
 var guideLastEventTime: TimeInterval?
 var paddleState: [Int: Bool] = [1: false, 2: false, 3: false, 4: false]
@@ -58,10 +58,9 @@ func emitGuideEvent(pressed: Bool, now: TimeInterval = CFAbsoluteTimeGetCurrent(
 
 	let eventGap = guideLastEventTime.map { now - $0 }
 	guideLastEventTime = now
-	if pressed, let eventGap, eventGap >= guideStalePressRecoveryInterval {
-		guidePressed = false
-		emit("{\"type\":\"guide\",\"pressed\":false}")
-		guidePressed = true
+	// Forward only the stale duplicate press. The app process owns release/press recovery
+	// across all raw Guide sources, which prevents helper + in-app HID from double-firing.
+	if pressed, let eventGap, eventGap >= guideDuplicateForwardInterval {
 		emit("{\"type\":\"guide\",\"pressed\":true}")
 	}
 }

--- a/Helpers/XboxEliteHelper.swift
+++ b/Helpers/XboxEliteHelper.swift
@@ -33,7 +33,9 @@ import IOKit.hid
 // MARK: - State
 
 let shouldEmitPaddles = !CommandLine.arguments.contains("--guide-only")
+let guideStalePressRecoveryInterval: TimeInterval = 2.0
 var guidePressed = false
+var guideLastEventTime: TimeInterval?
 var paddleState: [Int: Bool] = [1: false, 2: false, 3: false, 4: false]
 var knownDevices = Set<UnsafeMutableRawPointer>()
 var devicesWithExtendedButtons = Set<UnsafeMutableRawPointer>()
@@ -44,6 +46,24 @@ setbuf(stdout, nil)
 
 func emit(_ json: String) {
     print(json)
+}
+
+func emitGuideEvent(pressed: Bool, now: TimeInterval = CFAbsoluteTimeGetCurrent()) {
+	if pressed != guidePressed {
+		guidePressed = pressed
+		guideLastEventTime = now
+		emit("{\"type\":\"guide\",\"pressed\":\(pressed)}")
+		return
+	}
+
+	let eventGap = guideLastEventTime.map { now - $0 }
+	guideLastEventTime = now
+	if pressed, let eventGap, eventGap >= guideStalePressRecoveryInterval {
+		guidePressed = false
+		emit("{\"type\":\"guide\",\"pressed\":false}")
+		guidePressed = true
+		emit("{\"type\":\"guide\",\"pressed\":true}")
+	}
 }
 
 // MARK: - HID Setup
@@ -144,10 +164,7 @@ let inputCallback: IOHIDValueCallback = { _, _, _, value in
 		hasACHome: traits.hasACHome
 	) {
         let pressed = intValue != 0
-        if pressed != guidePressed {
-            guidePressed = pressed
-            emit("{\"type\":\"guide\",\"pressed\":\(pressed)}")
-        }
+		emitGuideEvent(pressed: pressed)
     }
 
     // Paddles: Consumer Page, usage 0x81 (4-bit bitmask)

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService+EliteHelper.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService+EliteHelper.swift
@@ -116,9 +116,13 @@ extension ControllerService {
         case "guide":
             if let pressed = json["pressed"] as? Bool {
                 guideLog("Elite helper: Guide \(pressed ? "PRESSED" : "RELEASED")")
-                controllerQueue.async { [weak self] in
-                    self?.handleButton(.xbox, pressed: pressed)
-                }
+				let events = eliteHelperGuideButtonEvents(pressed: pressed)
+				guard !events.isEmpty else { return }
+				controllerQueue.async { [weak self] in
+					for event in events {
+						self?.handleButton(event.button, pressed: event.pressed)
+					}
+				}
             }
 
         case "paddle":

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService.swift
@@ -9,6 +9,16 @@ import CoreAudio
 import AudioToolbox
 import AVFoundation
 
+struct ControllerButtonEvent: Equatable {
+	let button: ControllerButton
+	let pressed: Bool
+}
+
+private enum RawGuideEventSource: String {
+	case guideMonitor = "guide monitor"
+	case eliteHelper = "elite helper"
+}
+
 // MARK: - Thread-Safe Input State (High Performance)
 
 final class ControllerStorage: @unchecked Sendable {
@@ -86,6 +96,8 @@ final class ControllerStorage: @unchecked Sendable {
 	// visibility differs by Elite 2 firmware/connection mode.
 	var elitePaddleEventSource: ElitePaddleEventSource = .none
 	var eliteRawPaddleState: [Int: Bool] = [:]
+	var rawHIDGuidePressed = false
+	var rawHIDGuideLastEventTime: TimeInterval?
 
     // Chord Detection State
     var pendingButtons: Set<ControllerButton> = []
@@ -148,6 +160,8 @@ final class ControllerStorage: @unchecked Sendable {
 /// Service for managing game controller connection and input
 @MainActor
 class ControllerService: ObservableObject {
+	private static let rawGuideStalePressRecoveryInterval: TimeInterval = 2.0
+
     private static var isRunningTests: Bool {
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
@@ -613,9 +627,14 @@ class ControllerService: ObservableObject {
         }
 
         guideMonitor.onGuideButtonAction = { [weak self] isPressed in
-            self?.controllerQueue.async { [weak self] in
-                self?.handleButton(.xbox, pressed: isPressed)
-            }
+			guard let self else { return }
+			let events = self.guideMonitorGuideButtonEvents(pressed: isPressed)
+			guard !events.isEmpty else { return }
+			self.controllerQueue.async { [weak self] in
+				for event in events {
+					self?.handleButton(event.button, pressed: event.pressed)
+				}
+			}
         }
 
         guideMonitor.onPaddleAction = { [weak self] paddleIndex, isPressed in
@@ -632,6 +651,7 @@ class ControllerService: ObservableObject {
 		batteryMonitor.stopMonitoring()
 		cleanupGenericHIDMonitoring()
 		stopEliteHelper()
+		resetRawHIDGuideButtonState()
 	}
 
     private func setupNotifications() {
@@ -767,9 +787,11 @@ class ControllerService: ObservableObject {
         storage.lastLeftPaddleState = false
         storage.lastRightPaddleState = false
         storage.lastLeftFunctionState = false
-        storage.lastRightFunctionState = false
+		storage.lastRightFunctionState = false
 		storage.elitePaddleEventSource = .none
 		storage.eliteRawPaddleState.removeAll()
+		storage.rawHIDGuidePressed = false
+		storage.rawHIDGuideLastEventTime = nil
         storage.lock.unlock()
     }
 
@@ -808,6 +830,20 @@ class ControllerService: ObservableObject {
 		eliteRawHIDPaddleButton(for: paddleIndex, pressed: pressed)
 	}
 
+	nonisolated func guideMonitorGuideButtonEvents(
+		pressed: Bool,
+		now: TimeInterval = CFAbsoluteTimeGetCurrent()
+	) -> [ControllerButtonEvent] {
+		rawHIDGuideButtonEvents(source: .guideMonitor, pressed: pressed, now: now)
+	}
+
+	nonisolated func eliteHelperGuideButtonEvents(
+		pressed: Bool,
+		now: TimeInterval = CFAbsoluteTimeGetCurrent()
+	) -> [ControllerButtonEvent] {
+		rawHIDGuideButtonEvents(source: .eliteHelper, pressed: pressed, now: now)
+	}
+
 	private nonisolated func eliteRawHIDPaddleButton(for paddleIndex: Int, pressed: Bool) -> ControllerButton? {
 		guard let button = Self.xboxElitePaddleButton(for: paddleIndex) else { return nil }
 		storage.lock.lock()
@@ -818,6 +854,57 @@ class ControllerService: ObservableObject {
 		}
 		storage.eliteRawPaddleState[paddleIndex] = pressed
 		return button
+	}
+
+	private nonisolated func rawHIDGuideButtonEvents(
+		source: RawGuideEventSource,
+		pressed: Bool,
+		now: TimeInterval
+	) -> [ControllerButtonEvent] {
+		let result: (events: [ControllerButtonEvent], logMessage: String?)
+
+		storage.lock.lock()
+		if storage.rawHIDGuidePressed == pressed {
+			let eventGap = storage.rawHIDGuideLastEventTime.map { now - $0 }
+			storage.rawHIDGuideLastEventTime = now
+			if pressed,
+			   let eventGap,
+			   eventGap >= Self.rawGuideStalePressRecoveryInterval {
+				let gap = String(format: "%.2f", eventGap)
+				result = (
+					events: [
+						ControllerButtonEvent(button: .xbox, pressed: false),
+						ControllerButtonEvent(button: .xbox, pressed: true),
+					],
+					logMessage: "Raw Guide \(source.rawValue): stale press recovered after \(gap)s quiet gap"
+				)
+			} else {
+				result = (
+					events: [],
+					logMessage: "Raw Guide \(source.rawValue): duplicate \(pressed ? "press" : "release") ignored"
+				)
+			}
+		} else {
+			storage.rawHIDGuidePressed = pressed
+			storage.rawHIDGuideLastEventTime = now
+			result = (
+				events: [ControllerButtonEvent(button: .xbox, pressed: pressed)],
+				logMessage: "Raw Guide \(source.rawValue): \(pressed ? "press" : "release") routed"
+			)
+		}
+		storage.lock.unlock()
+
+		if let logMessage = result.logMessage {
+			guideLog(logMessage)
+		}
+		return result.events
+	}
+
+	private nonisolated func resetRawHIDGuideButtonState() {
+		storage.lock.lock()
+		storage.rawHIDGuidePressed = false
+		storage.rawHIDGuideLastEventTime = nil
+		storage.lock.unlock()
 	}
 
 	nonisolated static func xboxElitePaddleButton(for paddleIndex: Int) -> ControllerButton? {

--- a/XboxControllerMapper/XboxControllerMapperTests/ControllerServiceCallbackProxyTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ControllerServiceCallbackProxyTests.swift
@@ -160,6 +160,26 @@ final class ControllerServiceCallbackProxyTests: XCTestCase {
 		)
 	}
 
+	func testRawHIDGuideStaleRecoveryOnlyFiresOnceAcrossSources() {
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 50),
+			[ControllerButtonEvent(button: .xbox, pressed: true)]
+		)
+		XCTAssertEqual(
+			controllerService.eliteHelperGuideButtonEvents(pressed: true, now: 52.1),
+			[
+				ControllerButtonEvent(button: .xbox, pressed: false),
+				ControllerButtonEvent(button: .xbox, pressed: true),
+			],
+			"The first stale duplicate press recovers the missing release."
+		)
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 52.2),
+			[],
+			"A same-press report from the other raw source should not recover again."
+		)
+	}
+
 	func testRawHIDGuideDoesNotRecoverWhilePressedReportsContinue() {
 		XCTAssertEqual(
 			controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 40),

--- a/XboxControllerMapper/XboxControllerMapperTests/ControllerServiceCallbackProxyTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ControllerServiceCallbackProxyTests.swift
@@ -119,6 +119,72 @@ final class ControllerServiceCallbackProxyTests: XCTestCase {
 		XCTAssertFalse(ControllerService.shouldUseGlobalEliteHIDFallback(connectedXboxControllerCount: 2))
 	}
 
+	func testRawHIDGuideSourcesAreDedupedTogether() {
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 10),
+			[ControllerButtonEvent(button: .xbox, pressed: true)]
+		)
+		XCTAssertEqual(
+			controllerService.eliteHelperGuideButtonEvents(pressed: true, now: 10.1),
+			[],
+			"Same-state helper press should be ignored after guide monitor handled the press."
+		)
+		XCTAssertEqual(
+			controllerService.eliteHelperGuideButtonEvents(pressed: false, now: 10.2),
+			[ControllerButtonEvent(button: .xbox, pressed: false)]
+		)
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: false, now: 10.3),
+			[],
+			"Same-state guide monitor release should be ignored after helper handled the release."
+		)
+	}
+
+	func testRawHIDGuideStalePressRecoversMissingRelease() {
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 20),
+			[ControllerButtonEvent(button: .xbox, pressed: true)]
+		)
+		XCTAssertEqual(
+			controllerService.eliteHelperGuideButtonEvents(pressed: true, now: 21),
+			[],
+			"Near-term duplicate press should stay deduped so duplicate HID interfaces do not double fire."
+		)
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 23),
+			[
+				ControllerButtonEvent(button: .xbox, pressed: false),
+				ControllerButtonEvent(button: .xbox, pressed: true),
+			],
+			"A new press after a missing release should synthesize release then press."
+		)
+	}
+
+	func testRawHIDGuideDoesNotRecoverWhilePressedReportsContinue() {
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 40),
+			[ControllerButtonEvent(button: .xbox, pressed: true)]
+		)
+		XCTAssertEqual(controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 41), [])
+		XCTAssertEqual(controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 42.5), [])
+		XCTAssertEqual(controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 44), [])
+	}
+
+	func testRawHIDGuideReleaseClearsStateForLaterPress() {
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: true, now: 30),
+			[ControllerButtonEvent(button: .xbox, pressed: true)]
+		)
+		XCTAssertEqual(
+			controllerService.guideMonitorGuideButtonEvents(pressed: false, now: 30.2),
+			[ControllerButtonEvent(button: .xbox, pressed: false)]
+		)
+		XCTAssertEqual(
+			controllerService.eliteHelperGuideButtonEvents(pressed: true, now: 30.4),
+			[ControllerButtonEvent(button: .xbox, pressed: true)]
+		)
+	}
+
 	func testGuideMonitorPaddleButtonRequiresRawHIDSource() {
 		controllerService.writeStorage(\.elitePaddleEventSource, .none)
 


### PR DESCRIPTION
## Summary
- route raw Guide/Home events from the guide monitor and Elite helper through one shared state gate
- recover missing Guide release state by synthesizing release + press after a quiet duplicate press gap
- add the same quiet-gap recovery inside the standalone Elite helper before JSON emission
- add regression coverage for raw Guide source dedupe, stale recovery, held-report dedupe, and normal release reset

## Verification
- git diff --check
- swiftc -parse Helpers/XboxEliteHelper.swift
- xcodebuild test -project XboxControllerMapper/XboxControllerMapper.xcodeproj -scheme XboxControllerMapper -derivedDataPath /tmp/xcm-guide-state-gate-focused -destination 'platform=macOS' -only-testing:XboxControllerMapperTests/ControllerServiceCallbackProxyTests -only-testing:XboxControllerMapperTests/XboxGuideMonitorTests
- make install BUILD_FROM_SOURCE=1

## Notes
- Full test suite was attempted but is currently not a reliable signal in this worktree: existing ControllerLock tests failed and benchmark tests hit malloc crashes before this change area; the focused Elite/Guide regression gate passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Guide button reliability by deduplicating Guide input across multiple sources and performing stale-press recovery after a quiet gap.
  * Ensures stale recovery triggers only once and resets raw Guide state on cleanup/disconnect to avoid cross-session stuck state.

* **Tests**
  * Added tests covering cross-source deduplication, stale-press recovery scenarios, repeated-press behavior, and state reset after release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSEvent/xbox-controller-mapper/pull/21)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->