### PR TITLE
Fix controller battery reporting race

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/BatteryNotificationManager.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/BatteryNotificationManager.swift
@@ -1,50 +1,45 @@
 import Foundation
 import UserNotifications
 import Combine
+import GameController
 
 /// Monitors controller battery level and sends macOS notifications at low thresholds
 @MainActor
 class BatteryNotificationManager {
-    private var cancellables = Set<AnyCancellable>()
-    private var hasNotifiedAt20 = false
-    private var hasNotifiedAt10 = false
-    private var hasRequestedPermission = false
+	private var cancellables = Set<AnyCancellable>()
+	private var hasNotifiedAt20 = false
+	private var hasNotifiedAt10 = false
+	private var hasRequestedPermission = false
 
-    private let warningThreshold: Float = 0.20
-    private let criticalThreshold: Float = 0.10
-    private let resetMargin: Float = 0.05
+	private let warningThreshold: Float = 0.20
+	private let criticalThreshold: Float = 0.10
+	private let resetMargin: Float = 0.05
 
-    func startMonitoring(controllerService: ControllerService) {
-        controllerService.$batteryLevel
-            .removeDuplicates()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] level in
-                self?.handleBatteryUpdate(level: level)
-            }
-            .store(in: &cancellables)
+	func startMonitoring(controllerService: ControllerService) {
+		controllerService.$batteryLevel
+			.combineLatest(controllerService.$batteryState, controllerService.$isConnected)
+			.receive(on: DispatchQueue.main)
+			.sink { [weak self] update in
+				let (level, state, isConnected) = update
+				if isConnected {
+					self?.handleBatteryUpdate(level: level, state: state)
+				} else {
+					self?.reset()
+				}
+			}
+			.store(in: &cancellables)
+	}
 
-        // Reset notification state on disconnect
-        controllerService.$isConnected
-            .removeDuplicates()
-            .filter { $0 == false }
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.reset()
-            }
-            .store(in: &cancellables)
-    }
+	private func handleBatteryUpdate(level: Float, state: GCDeviceBattery.State) {
+		guard ControllerBatteryDisplayPolicy.isKnown(level: level, state: state) else { return }
 
-    private func handleBatteryUpdate(level: Float) {
-        // Ignore unknown/invalid battery levels
-        guard level >= 0 && level <= 1.0 else { return }
-
-        // Reset flags when charged above threshold + margin
-        if level > warningThreshold + resetMargin {
-            hasNotifiedAt20 = false
-        }
-        if level > criticalThreshold + resetMargin {
-            hasNotifiedAt10 = false
-        }
+		// Reset flags when charged above threshold + margin
+		if level > warningThreshold + resetMargin {
+			hasNotifiedAt20 = false
+		}
+		if level > criticalThreshold + resetMargin {
+			hasNotifiedAt10 = false
+		}
 
         // Check critical threshold (10%)
         if level <= criticalThreshold && !hasNotifiedAt10 {

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerBatteryPolicy.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerBatteryPolicy.swift
@@ -1,0 +1,52 @@
+import Foundation
+import GameController
+
+struct ControllerBatteryReading {
+	let level: Float
+	let state: GCDeviceBattery.State
+}
+
+enum ControllerBatteryDisplayPolicy {
+	static func isKnown(level: Float, state: GCDeviceBattery.State) -> Bool {
+		guard level >= 0, level <= 1.0 else { return false }
+		return !(level == 0 && state == .unknown)
+	}
+
+	static func percentage(level: Float, state: GCDeviceBattery.State) -> Int? {
+		guard isKnown(level: level, state: state) else { return nil }
+		return Int((level * 100).rounded())
+	}
+}
+
+enum ControllerBatteryReadingResolver {
+	static func resolve(
+		isXbox: Bool,
+		bluetoothLevel: Int?,
+		bluetoothIsCharging: Bool,
+		controllerBatteryLevel: Float?,
+		controllerBatteryState: GCDeviceBattery.State?
+	) -> ControllerBatteryReading? {
+		if isXbox {
+			guard let bluetoothLevel else { return nil }
+			let clampedLevel = min(100, max(0, bluetoothLevel))
+			return ControllerBatteryReading(
+				level: Float(clampedLevel) / 100.0,
+				state: bluetoothIsCharging ? .charging : .discharging
+			)
+		}
+
+		guard let controllerBatteryLevel,
+			  let controllerBatteryState,
+			  ControllerBatteryDisplayPolicy.isKnown(
+				  level: controllerBatteryLevel,
+				  state: controllerBatteryState
+			  ) else {
+			return nil
+		}
+
+		return ControllerBatteryReading(
+			level: controllerBatteryLevel,
+			state: controllerBatteryState
+		)
+	}
+}

--- a/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Controller/ControllerService.swift
@@ -1117,20 +1117,23 @@ class ControllerService: ObservableObject {
     }
 
     func updateBatteryInfo() {
-        // Use appropriate battery source based on controller type:
-        // - DualSense: GCController.battery works reliably
-        // - Xbox: Use BluetoothBatteryMonitor workaround (GCController often returns -1/0 on macOS)
-        let isDualSense = threadSafeIsDualSense
-
-        if !isDualSense, let ioLevel = batteryMonitor.batteryLevel {
-            // Xbox controller: prefer Bluetooth monitor (macOS workaround)
-            batteryLevel = Float(ioLevel) / 100.0
-            batteryState = batteryMonitor.isCharging ? .charging : .discharging
-        } else if let battery = connectedController?.battery {
-            // DualSense or Xbox fallback: use GCController battery
-            batteryLevel = battery.batteryLevel
-            batteryState = battery.batteryState
-        }
+		// Xbox battery over GameController is unreliable on macOS and can report
+		// 0%/.unknown before the Bluetooth Battery Service read completes.
+		let isXbox = connectedController?.extendedGamepad is GCXboxGamepad
+		let controllerBattery = connectedController?.battery
+		if let reading = ControllerBatteryReadingResolver.resolve(
+			isXbox: isXbox,
+			bluetoothLevel: batteryMonitor.batteryLevel,
+			bluetoothIsCharging: batteryMonitor.isCharging,
+			controllerBatteryLevel: controllerBattery?.batteryLevel,
+			controllerBatteryState: controllerBattery?.batteryState
+		) {
+			batteryLevel = reading.level
+			batteryState = reading.state
+		} else {
+			batteryLevel = -1
+			batteryState = .unknown
+		}
 
         // Update battery light bar if enabled
         updateBatteryLightBar()

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ControllerVisualView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ControllerVisualView.swift
@@ -2319,7 +2319,11 @@ struct BatteryView: View {
     
     // Xbox controllers on macOS often report 0.0 with unknown state when data is unavailable
     private var isUnknown: Bool {
-        level < 0 || (level == 0 && state == .unknown)
+		!ControllerBatteryDisplayPolicy.isKnown(level: level, state: state)
+    }
+
+    private var percentage: Int? {
+		ControllerBatteryDisplayPolicy.percentage(level: level, state: state)
     }
     
     var body: some View {
@@ -2349,7 +2353,7 @@ struct BatteryView: View {
                             .fill(batteryColor)
                             .frame(width: max(2, 28 * CGFloat(level)), height: 12)
                         
-                        Text("\(Int(level * 100))%")
+						Text("\(percentage ?? 0)%")
                             .font(.system(size: 8, weight: .bold))
                             .foregroundColor(.white)
                             .shadow(color: .black.opacity(0.6), radius: 1, x: 0, y: 0)
@@ -2370,8 +2374,8 @@ struct BatteryView: View {
                 .fill(Color.primary.opacity(0.4))
                 .frame(width: 2, height: 4)
         }
-        .help(isUnknown ? "Battery level unavailable (common macOS limitation for Xbox controllers)" : "Battery: \(Int(level * 100))%")
-        .accessibilityLabel(isUnknown ? "Battery unavailable" : "Battery: \(Int(level * 100)) percent")
+		.help(percentage.map { "Battery: \($0)%" } ?? "Battery level unavailable (common macOS limitation for Xbox controllers)")
+		.accessibilityLabel(percentage.map { "Battery: \($0) percent" } ?? "Battery unavailable")
     }
     
     private var batteryColor: Color {

--- a/XboxControllerMapper/XboxControllerMapper/Views/MenuBar/MenuBarView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MenuBar/MenuBarView.swift
@@ -1,4 +1,5 @@
 import Combine
+import GameController
 import SwiftUI
 
 extension Notification.Name {
@@ -117,6 +118,13 @@ struct MenuBarView: View {
                 }
 
                 Spacer()
+
+				if controllerService.isConnected {
+					MenuBarBatteryBadge(
+						level: controllerService.batteryLevel,
+						state: controllerService.batteryState
+					)
+				}
             }
 
             // Accessibility permission status
@@ -268,6 +276,56 @@ struct MenuBarView: View {
 
     private func quitApp() {
         NSApp.terminate(nil)
+    }
+}
+
+private struct MenuBarBatteryBadge: View {
+    let level: Float
+    let state: GCDeviceBattery.State
+
+    private var percentage: Int? {
+		ControllerBatteryDisplayPolicy.percentage(level: level, state: state)
+    }
+
+    private var batterySymbolName: String {
+		guard let percentage else { return "battery.0percent" }
+		if percentage >= 88 { return "battery.100percent" }
+		if percentage >= 63 { return "battery.75percent" }
+		if percentage >= 38 { return "battery.50percent" }
+		if percentage >= 13 { return "battery.25percent" }
+		return "battery.0percent"
+    }
+
+    private var tint: Color {
+		guard let percentage else { return .secondary }
+		if state == .charging { return .green }
+		if percentage > 60 { return .green }
+		if percentage > 20 { return .orange }
+		return .red
+    }
+
+    var body: some View {
+		HStack(spacing: 4) {
+			if state == .charging, percentage != nil {
+				Image(systemName: "bolt.fill")
+					.font(.system(size: 9, weight: .bold))
+					.foregroundColor(.yellow)
+			}
+
+			Image(systemName: batterySymbolName)
+				.font(.system(size: 12, weight: .semibold))
+
+			Text(percentage.map { "\($0)%" } ?? "--")
+				.font(.caption.weight(.semibold))
+				.monospacedDigit()
+		}
+		.foregroundColor(tint)
+		.padding(.horizontal, 7)
+		.padding(.vertical, 4)
+		.background(Color.primary.opacity(0.07))
+		.cornerRadius(6)
+		.help(percentage.map { "Battery: \($0)%" } ?? "Battery unavailable")
+		.accessibilityLabel(percentage.map { "Battery: \($0) percent" } ?? "Battery unavailable")
     }
 }
 

--- a/XboxControllerMapper/XboxControllerMapperTests/ControllerBatteryPolicyTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ControllerBatteryPolicyTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+import GameController
+@testable import ControllerKeys
+
+final class ControllerBatteryPolicyTests: XCTestCase {
+	func testXboxWaitsForBluetoothBatteryInsteadOfTrustingInitialGameControllerZero() {
+		let reading = ControllerBatteryReadingResolver.resolve(
+			isXbox: true,
+			bluetoothLevel: nil,
+			bluetoothIsCharging: false,
+			controllerBatteryLevel: 0,
+			controllerBatteryState: .unknown
+		)
+
+		XCTAssertNil(reading)
+	}
+
+	func testXboxUsesBluetoothBatteryWhenAvailable() {
+		let reading = ControllerBatteryReadingResolver.resolve(
+			isXbox: true,
+			bluetoothLevel: 82,
+			bluetoothIsCharging: false,
+			controllerBatteryLevel: 0,
+			controllerBatteryState: .unknown
+		)
+
+		XCTAssertNotNil(reading)
+		XCTAssertEqual(reading?.level ?? -1, 0.82, accuracy: 0.001)
+		XCTAssertEqual(reading?.state, .discharging)
+	}
+
+	func testXboxBluetoothBatteryIsClamped() {
+		let reading = ControllerBatteryReadingResolver.resolve(
+			isXbox: true,
+			bluetoothLevel: 125,
+			bluetoothIsCharging: true,
+			controllerBatteryLevel: nil,
+			controllerBatteryState: nil
+		)
+
+		XCTAssertNotNil(reading)
+		XCTAssertEqual(reading?.level ?? -1, 1.0, accuracy: 0.001)
+		XCTAssertEqual(reading?.state, .charging)
+	}
+
+	func testNonXboxUsesKnownGameControllerBattery() {
+		let reading = ControllerBatteryReadingResolver.resolve(
+			isXbox: false,
+			bluetoothLevel: nil,
+			bluetoothIsCharging: false,
+			controllerBatteryLevel: 0.19,
+			controllerBatteryState: .discharging
+		)
+
+		XCTAssertNotNil(reading)
+		XCTAssertEqual(reading?.level ?? -1, 0.19, accuracy: 0.001)
+		XCTAssertEqual(reading?.state, .discharging)
+	}
+
+	func testUnknownZeroBatteryIsNotDisplayableOrNotifiable() {
+		XCTAssertFalse(
+			ControllerBatteryDisplayPolicy.isKnown(level: 0, state: .unknown)
+		)
+		XCTAssertNil(
+			ControllerBatteryDisplayPolicy.percentage(level: 0, state: .unknown)
+		)
+	}
+
+	func testZeroDischargingBatteryIsKnownCritical() {
+		XCTAssertTrue(
+			ControllerBatteryDisplayPolicy.isKnown(level: 0, state: .discharging)
+		)
+		XCTAssertEqual(
+			ControllerBatteryDisplayPolicy.percentage(level: 0, state: .discharging),
+			0
+		)
+	}
+}


### PR DESCRIPTION
## Summary
- wait for Bluetooth Battery Service readings before trusting Xbox battery level
- share known/unknown battery policy across notifications, main controller view, and menu bar popup
- show a compact battery badge in the menu bar popup header
- add regression coverage for Xbox initial 0%/.unknown battery reports

Closes #18
Closes #19

## Tests
- xcodebuild test -project XboxControllerMapper/XboxControllerMapper.xcodeproj -scheme XboxControllerMapper -derivedDataPath /tmp/xcm-derived-data-battery-policy -destination 'platform=macOS' -only-testing:XboxControllerMapperTests/ControllerBatteryPolicyTests
- git diff --cached --check

## Notes
- make test-full was interrupted after unrelated existing instability: malloc free crashes during the full suite and ControllerLockTests failures after restart with orphaned activeProfileId warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added battery status indicator in the menu bar displaying controller battery level and charging state.

* **Improvements**
  * Enhanced battery state monitoring with more accurate detection of charging and discharging status.
  * Improved battery display accuracy across different controller types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NSEvent/xbox-controller-mapper/pull/22)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->