### PR TITLE
🎨 Palette: Add tooltips and accessibility labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-03 - Missing tooltips and accessibility on list item actions
+**Learning:** Icon-only buttons used for item actions (like 'Edit', 'Delete', 'Remove') within list views often lack tooltips and accessibility labels. This omission makes the UI ambiguous for mouse users on macOS and inaccessible to screen readers.
+**Action:** Always add `.help("Action Name")` and `.accessibilityLabel("Action Name Item Type")` to icon-only buttons, especially those located at the trailing edge of list rows.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
@@ -176,7 +176,7 @@ struct CommandWheelActionRow: View {
             .buttonStyle(.plain)
             .foregroundColor(.secondary)
             .help("Edit")
-            .accessibilityLabel("Edit")
+            .accessibilityLabel("Edit Command Wheel Action")
 
             // Delete button
             Button(action: onDelete) {
@@ -186,7 +186,7 @@ struct CommandWheelActionRow: View {
             .buttonStyle(.plain)
             .foregroundColor(.secondary)
             .help("Delete")
-            .accessibilityLabel("Delete")
+            .accessibilityLabel("Delete Command Wheel Action")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 6)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
@@ -175,6 +175,8 @@ struct CommandWheelActionRow: View {
             }
             .buttonStyle(.plain)
             .foregroundColor(.secondary)
+            .help("Edit")
+            .accessibilityLabel("Edit")
 
             // Delete button
             Button(action: onDelete) {
@@ -183,6 +185,8 @@ struct CommandWheelActionRow: View {
             }
             .buttonStyle(.plain)
             .foregroundColor(.secondary)
+            .help("Delete")
+            .accessibilityLabel("Delete")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 6)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
@@ -57,6 +57,8 @@ struct LinkedAppsSheet: View {
                                     .foregroundColor(.red)
                             }
                             .buttonStyle(.borderless)
+                            .help("Remove")
+                            .accessibilityLabel("Remove Linked App")
                         }
                         .padding(.vertical, 4)
                     }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedControllersSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedControllersSheet.swift
@@ -56,6 +56,8 @@ struct LinkedControllersSheet: View {
                                     .foregroundColor(.red)
                             }
                             .buttonStyle(.borderless)
+                            .help("Remove")
+                            .accessibilityLabel("Remove Linked Controller")
                         }
                         .padding(.vertical, 4)
                     }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SwipeTypingSection.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SwipeTypingSection.swift
@@ -99,6 +99,8 @@ struct SwipeTypingSection: View {
                                     .foregroundColor(.red)
                             }
                             .buttonStyle(.borderless)
+                            .help("Delete")
+                            .accessibilityLabel("Delete Custom Word")
                         }
                     }
                 }


### PR DESCRIPTION
**💡 What:** Added `.help("...")` tooltips and `.accessibilityLabel("...")` to icon-only buttons (like "Edit" and "Delete/Remove" actions) in various list views (CommandWheelSettingsView, LinkedAppsSheet, LinkedControllersSheet, and SwipeTypingSection).

**🎯 Why:** These buttons lacked context for mouse users and were completely inaccessible to screen readers. Adding tooltips provides helpful visual context on hover, while accessibility labels ensure VoiceOver users can understand the button's action. 

**📸 Before/After:** Hovering over the buttons now displays a tooltip with the action name, and screen readers will announce the appropriate action instead of just "button".

**♿ Accessibility:** Enhanced VoiceOver compatibility by ensuring all interactive icon elements have a descriptive label.

Ref: `.Jules/palette.md` for journal entry regarding this UI pattern.

---
*PR created automatically by Jules for task [7319784249144209957](https://jules.google.com/task/7319784249144209957) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on making icon-only action buttons accessible (tooltips and accessibility labels).

* **New Features**
  * Added help tooltips and explicit accessibility labels to action buttons across command wheel settings, linked apps, linked controllers, and custom-word management to improve discoverability and screen-reader clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->