### PR TITLE
⚡ Cache DateFormatter in ConfigBackupService for Performance

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Services/Profile/ConfigBackupService.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Profile/ConfigBackupService.swift
@@ -3,6 +3,12 @@ import Foundation
 struct ConfigBackupService {
     private let fileManager: FileManager
 
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        return formatter
+    }()
+
     init(fileManager: FileManager = .default) {
         self.fileManager = fileManager
     }
@@ -21,9 +27,7 @@ struct ConfigBackupService {
             return
         }
 
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-        let timestamp = dateFormatter.string(from: Date())
+        let timestamp = Self.dateFormatter.string(from: Date())
         let backupURL = backupDir.appendingPathComponent("config_\(timestamp).json")
 
         do {


### PR DESCRIPTION
💡 **What:**
Moved the initialization of `DateFormatter` out of the `createBackupIfNeeded` method and into a static property on `ConfigBackupService`. 

🎯 **Why:**
`DateFormatter` instantiation in Foundation is known to be an expensive operation. Since `ConfigBackupService` creates a backup very often using the same fixed date format (`yyyy-MM-dd_HH-mm-ss`), instantiating a new parser every time a backup is made incurs unnecessary overhead. Reusing a single static instance completely avoids this redundant parsing overhead and memory allocation.

📊 **Measured Improvement:**
Since this project runs in a Linux sandbox environment without access to the Swift toolchain or `xcodebuild` tools, I was unable to compile and capture empirical benchmark measurements for this exact codebase on a physical macOS device. However, this is a well-documented Foundation performance bottleneck, and replacing repeated instantiation with a single static instance is widely accepted as a best practice in Swift to achieve measurable time-saving and memory optimizations.

---
*PR created automatically by Jules for task [18220135439705320643](https://jules.google.com/task/18220135439705320643) started by @NSEvent*