### PR TITLE
⚡ Optimize DateFormatter instantiation in VariableExpander

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Utilities/VariableExpander.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Utilities/VariableExpander.swift
@@ -80,6 +80,8 @@ enum VariableExpander {
         // Find all matches (process in reverse to preserve indices)
         let matches = regex.matches(in: text, options: [], range: NSRange(text.startIndex..., in: text))
 
+        let formatter = DateFormatter()
+
         for match in matches.reversed() {
             guard let fullRange = Range(match.range, in: result),
                   let varNameRange = Range(match.range(at: 1), in: result) else {
@@ -88,7 +90,7 @@ enum VariableExpander {
 
             let variableName = String(result[varNameRange])
 
-            if let value = resolveVariable(variableName) {
+            if let value = resolveVariable(variableName, formatter: formatter) {
                 result.replaceSubrange(fullRange, with: value)
             }
             // If variable cannot be resolved, leave it unchanged
@@ -100,9 +102,8 @@ enum VariableExpander {
     // MARK: - Variable Resolution
 
     /// Resolves a single variable name to its value
-    private static func resolveVariable(_ name: String) -> String? {
+    private static func resolveVariable(_ name: String, formatter: DateFormatter) -> String? {
         let now = Date()
-        let formatter = DateFormatter()
 
         switch name {
         // Date formats


### PR DESCRIPTION
💡 **What:** Moved the `DateFormatter` instantiation in `VariableExpander.swift` out of the inner string matching loop. Instantiated it once at the top level of the `expand(_:)` method and pass it into `resolveVariable(_:formatter:)`.

🎯 **Why:** `DateFormatter` is a notorious performance bottleneck in Swift due to its expensive instantiation cost. Creating a new one for every regex match of `{date}` or `{time}` caused significant overhead. By reusing the single instance, we get the exact same behavior but drastically improve performance for strings containing many variables.

📊 **Measured Improvement:** The AI agent sandbox runs on Linux without the Swift toolchain or `xcodebuild`, so running benchmarks or unit tests was unfortunately not possible. However, this is a very well-known Swift performance pattern. `DateFormatter` caching routinely improves looping throughput by 10x-100x depending on string length.

---
*PR created automatically by Jules for task [7387753833199993845](https://jules.google.com/task/7387753833199993845) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved efficiency of variable expansion by optimizing date/time formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->