### PR TITLE
🧹 Extract systemImageName helper

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Models/ControllerButton.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Models/ControllerButton.swift
@@ -448,88 +448,92 @@ enum ControllerButton: String, Codable, CaseIterable, Identifiable, Sendable {
 
     /// SF Symbol name appropriate for the controller type
     func systemImageName(forDualSense isDualSense: Bool) -> String? {
-        if isDualSense {
-            switch self {
-            case .dpadUp: return "arrowtriangle.up.fill"
-            case .dpadDown: return "arrowtriangle.down.fill"
-            case .dpadLeft: return "arrowtriangle.left.fill"
-            case .dpadRight: return "arrowtriangle.right.fill"
-            case .leftStickUp, .rightStickUp: return "arrow.up.circle"
-            case .leftStickDown, .rightStickDown: return "arrow.down.circle"
-            case .leftStickLeft, .rightStickLeft: return "arrow.left.circle"
-            case .leftStickRight, .rightStickRight: return "arrow.right.circle"
-            case .leftStickUpLeft, .rightStickUpLeft: return "arrow.up.left.circle"
-            case .leftStickUpRight, .rightStickUpRight: return "arrow.up.right.circle"
-            case .leftStickDownLeft, .rightStickDownLeft: return "arrow.down.left.circle"
-            case .leftStickDownRight, .rightStickDownRight: return "arrow.down.right.circle"
-            case .menu: return "line.3.horizontal"
-            case .view: return "square.and.arrow.up"  // Create/Share button (upload icon)
-            case .share: return "square.and.arrow.up"
-            case .xbox: return "playstation.logo"  // PS button
-            case .leftThumbstick: return "l3.button.angledbottom.horizontal.left"
-            case .rightThumbstick: return "r3.button.angledbottom.horizontal.right"
-            case .touchpadButton: return "hand.point.up.left"
-            case .touchpadTwoFingerButton: return nil  // Use text label "2P"
-            case .touchpadTap: return "hand.tap"
-            case .touchpadTwoFingerTap: return "hand.tap"
-            case .micMute: return "mic.slash"
-            case .leftTouchpadButton, .rightTouchpadButton: return "hand.point.up.left"
-            case .leftTouchpadTap, .rightTouchpadTap: return "hand.tap"
-            case .touchpadRegionTopLeftClick, .touchpadRegionTopLeftTouch,
-                 .touchpadRegionTopRightClick, .touchpadRegionTopRightTouch,
-                 .touchpadRegionBottomLeftClick, .touchpadRegionBottomLeftTouch,
-                 .touchpadRegionBottomRightClick, .touchpadRegionBottomRightTouch:
-                // Custom 2×2 quadrant indicator drawn by ButtonIconView; no
-                // SF Symbol used for these.
-                return nil
-            case .leftPaddle: return "l.button.roundedbottom.horizontal"
-            case .rightPaddle: return "r.button.roundedbottom.horizontal"
-            case .leftFunction: return "button.horizontal.top.press"
-            case .rightFunction: return "button.horizontal.top.press"
-            // Face buttons use text symbols for DualSense, not SF Symbols
-            case .a, .b, .x, .y: return nil
-            default: return nil
-            }
-        } else {
-            switch self {
-            case .dpadUp: return "arrowtriangle.up.fill"
-            case .dpadDown: return "arrowtriangle.down.fill"
-            case .dpadLeft: return "arrowtriangle.left.fill"
-            case .dpadRight: return "arrowtriangle.right.fill"
-            case .leftStickUp, .rightStickUp: return "arrow.up.circle"
-            case .leftStickDown, .rightStickDown: return "arrow.down.circle"
-            case .leftStickLeft, .rightStickLeft: return "arrow.left.circle"
-            case .leftStickRight, .rightStickRight: return "arrow.right.circle"
-            case .leftStickUpLeft, .rightStickUpLeft: return "arrow.up.left.circle"
-            case .leftStickUpRight, .rightStickUpRight: return "arrow.up.right.circle"
-            case .leftStickDownLeft, .rightStickDownLeft: return "arrow.down.left.circle"
-            case .leftStickDownRight, .rightStickDownRight: return "arrow.down.right.circle"
-            case .menu: return "line.3.horizontal"
-            case .view: return "rectangle.on.rectangle"
-            case .share: return "square.and.arrow.up"
-            case .xbox: return "xbox.logo"
-			case .siri: return "mic.fill"
-			case .appleTVRemotePower: return "power"
-			case .appleTVRemoteVolumeUp: return "speaker.wave.3.fill"
-			case .appleTVRemoteVolumeDown: return "speaker.wave.1.fill"
-			case .appleTVRemoteMute: return "speaker.slash.fill"
-            case .leftThumbstick: return "l.circle"
-            case .rightThumbstick: return "r.circle"
-            case .a: return "a.circle"
-            case .b: return "b.circle"
-            case .x: return "x.circle"
-            case .y: return "y.circle"
-            case .touchpadButton: return "hand.point.up.left"
-            case .touchpadTap: return "hand.tap"
-            case .leftTouchpadButton, .rightTouchpadButton: return "hand.point.up.left"
-            case .leftTouchpadTap, .rightTouchpadTap: return "hand.tap"
-            case .micMute: return "mic.slash"
-            case .xboxPaddle1: return "l.button.roundedbottom.horizontal"
-            case .xboxPaddle2: return "r.button.roundedbottom.horizontal"
-            case .xboxPaddle3: return "l.button.roundedbottom.horizontal.fill"
-            case .xboxPaddle4: return "r.button.roundedbottom.horizontal.fill"
-            default: return nil
-            }
+        return isDualSense ? dualSenseSystemImageName : xboxSystemImageName
+    }
+
+    private var dualSenseSystemImageName: String? {
+        switch self {
+        case .dpadUp: return "arrowtriangle.up.fill"
+        case .dpadDown: return "arrowtriangle.down.fill"
+        case .dpadLeft: return "arrowtriangle.left.fill"
+        case .dpadRight: return "arrowtriangle.right.fill"
+        case .leftStickUp, .rightStickUp: return "arrow.up.circle"
+        case .leftStickDown, .rightStickDown: return "arrow.down.circle"
+        case .leftStickLeft, .rightStickLeft: return "arrow.left.circle"
+        case .leftStickRight, .rightStickRight: return "arrow.right.circle"
+        case .leftStickUpLeft, .rightStickUpLeft: return "arrow.up.left.circle"
+        case .leftStickUpRight, .rightStickUpRight: return "arrow.up.right.circle"
+        case .leftStickDownLeft, .rightStickDownLeft: return "arrow.down.left.circle"
+        case .leftStickDownRight, .rightStickDownRight: return "arrow.down.right.circle"
+        case .menu: return "line.3.horizontal"
+        case .view: return "square.and.arrow.up"  // Create/Share button (upload icon)
+        case .share: return "square.and.arrow.up"
+        case .xbox: return "playstation.logo"  // PS button
+        case .leftThumbstick: return "l3.button.angledbottom.horizontal.left"
+        case .rightThumbstick: return "r3.button.angledbottom.horizontal.right"
+        case .touchpadButton: return "hand.point.up.left"
+        case .touchpadTwoFingerButton: return nil  // Use text label "2P"
+        case .touchpadTap: return "hand.tap"
+        case .touchpadTwoFingerTap: return "hand.tap"
+        case .micMute: return "mic.slash"
+        case .leftTouchpadButton, .rightTouchpadButton: return "hand.point.up.left"
+        case .leftTouchpadTap, .rightTouchpadTap: return "hand.tap"
+        case .touchpadRegionTopLeftClick, .touchpadRegionTopLeftTouch,
+             .touchpadRegionTopRightClick, .touchpadRegionTopRightTouch,
+             .touchpadRegionBottomLeftClick, .touchpadRegionBottomLeftTouch,
+             .touchpadRegionBottomRightClick, .touchpadRegionBottomRightTouch:
+            // Custom 2×2 quadrant indicator drawn by ButtonIconView; no
+            // SF Symbol used for these.
+            return nil
+        case .leftPaddle: return "l.button.roundedbottom.horizontal"
+        case .rightPaddle: return "r.button.roundedbottom.horizontal"
+        case .leftFunction: return "button.horizontal.top.press"
+        case .rightFunction: return "button.horizontal.top.press"
+        // Face buttons use text symbols for DualSense, not SF Symbols
+        case .a, .b, .x, .y: return nil
+        default: return nil
+        }
+    }
+
+    private var xboxSystemImageName: String? {
+        switch self {
+        case .dpadUp: return "arrowtriangle.up.fill"
+        case .dpadDown: return "arrowtriangle.down.fill"
+        case .dpadLeft: return "arrowtriangle.left.fill"
+        case .dpadRight: return "arrowtriangle.right.fill"
+        case .leftStickUp, .rightStickUp: return "arrow.up.circle"
+        case .leftStickDown, .rightStickDown: return "arrow.down.circle"
+        case .leftStickLeft, .rightStickLeft: return "arrow.left.circle"
+        case .leftStickRight, .rightStickRight: return "arrow.right.circle"
+        case .leftStickUpLeft, .rightStickUpLeft: return "arrow.up.left.circle"
+        case .leftStickUpRight, .rightStickUpRight: return "arrow.up.right.circle"
+        case .leftStickDownLeft, .rightStickDownLeft: return "arrow.down.left.circle"
+        case .leftStickDownRight, .rightStickDownRight: return "arrow.down.right.circle"
+        case .menu: return "line.3.horizontal"
+        case .view: return "rectangle.on.rectangle"
+        case .share: return "square.and.arrow.up"
+        case .xbox: return "xbox.logo"
+        case .siri: return "mic.fill"
+        case .appleTVRemotePower: return "power"
+        case .appleTVRemoteVolumeUp: return "speaker.wave.3.fill"
+        case .appleTVRemoteVolumeDown: return "speaker.wave.1.fill"
+        case .appleTVRemoteMute: return "speaker.slash.fill"
+        case .leftThumbstick: return "l.circle"
+        case .rightThumbstick: return "r.circle"
+        case .a: return "a.circle"
+        case .b: return "b.circle"
+        case .x: return "x.circle"
+        case .y: return "y.circle"
+        case .touchpadButton: return "hand.point.up.left"
+        case .touchpadTap: return "hand.tap"
+        case .leftTouchpadButton, .rightTouchpadButton: return "hand.point.up.left"
+        case .leftTouchpadTap, .rightTouchpadTap: return "hand.tap"
+        case .micMute: return "mic.slash"
+        case .xboxPaddle1: return "l.button.roundedbottom.horizontal"
+        case .xboxPaddle2: return "r.button.roundedbottom.horizontal"
+        case .xboxPaddle3: return "l.button.roundedbottom.horizontal.fill"
+        case .xboxPaddle4: return "r.button.roundedbottom.horizontal.fill"
+        default: return nil
         }
     }
 


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted large inline switch statements from `systemImageName(forDualSense:)` into dedicated private properties `dualSenseSystemImageName` and `xboxSystemImageName`.

💡 **Why:** How this improves maintainability
The original function was long and contained two very large switch statements nested within an if/else block. By delegating the resolution of the SF Symbol name to smaller, purpose-built helper properties, the main function is now a single, highly readable line.

✅ **Verification:** How you confirmed the change is safe
Tests could not be run directly (due to lack of `xcodebuild` in the execution environment), but the logic changes were carefully checked to ensure they are 1:1 functionally equivalent. Verified via syntactic code review.

✨ **Result:** The improvement achieved
A cleaner, more readable `ControllerButton.swift` file without changing existing behavior.

---
*PR created automatically by Jules for task [2594764583829077565](https://jules.google.com/task/2594764583829077565) started by @NSEvent*