### PR TITLE
🔒 Fix unvalidated unzip process arguments vulnerability

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Services/Profile/StreamDeckProfileParser.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Profile/StreamDeckProfileParser.swift
@@ -140,6 +140,17 @@ enum StreamDeckProfileParser {
     }
 
     private static func extractAndLoadManifest(from url: URL) throws -> Data {
+        guard url.isFileURL else {
+            throw StreamDeckParseError.extractionFailed("URL must be a file URL")
+        }
+
+        let sourcePath = url.path
+
+        // Ensure it's an absolute path to prevent argument injection
+        guard sourcePath.hasPrefix("/") else {
+            throw StreamDeckParseError.extractionFailed("Invalid file path: must be an absolute path")
+        }
+
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("streamdeck-import-\(UUID().uuidString)")
         defer { try? FileManager.default.removeItem(at: tempDir) }


### PR DESCRIPTION
Addresses an argument injection vulnerability in the `StreamDeckProfileParser.swift` file.

* 🎯 **What:** An unvalidated URL path was being passed directly to an `unzip` process argument list. This allowed for potential argument injection if the path started with a `-`, treating the path as a command-line flag rather than a file.
* ⚠️ **Risk:** An attacker could craft a malicious `.streamDeckProfile` payload file named with a `-` prefix (e.g., `-T`), leading to unexpected behavior by the `unzip` command, potentially causing file traversal, arbitrary reads, or command execution.
* 🛡️ **Solution:** Added a guard statement validating that the file path is an absolute path (begins with `/`). This guarantees that the path cannot be interpreted as a command-line flag. Also verified the URL is a file URL.

---
*PR created automatically by Jules for task [2371256969785480493](https://jules.google.com/task/2371256969785480493) started by @NSEvent*