### PR TITLE
🧹 Refactor `scroll` method to use `ScrollEvent` struct

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
@@ -1133,14 +1133,21 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
     /// Scrolls by a delta
     func scroll(event scrollEvent: ScrollEvent) {
+        let dx = scrollEvent.dx
+        let dy = scrollEvent.dy
+        let phase = scrollEvent.phase
+        let momentumPhase = scrollEvent.momentumPhase
+        let isContinuous = scrollEvent.isContinuous
+        let flags = scrollEvent.flags
+
         if shouldRelayUniversalControlAction(),
            UniversalControlMouseRelay.shared.sendScroll(
-                dx: scrollEvent.dx,
-                dy: scrollEvent.dy,
-                phase: scrollEvent.phase,
-                momentumPhase: scrollEvent.momentumPhase,
-                isContinuous: scrollEvent.isContinuous,
-                flags: scrollEvent.flags
+                dx: dx,
+                dy: dy,
+                phase: phase,
+                momentumPhase: momentumPhase,
+                isContinuous: isContinuous,
+                flags: flags
            ) {
             return
         }
@@ -1148,8 +1155,8 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         // Check if Control is held - if so, convert to Accessibility Zoom keyboard shortcuts
         // macOS Accessibility Zoom doesn't respond to synthetic Control+scroll events,
         // but does respond to Option+Command+Plus/Minus keyboard shortcuts
-        if scrollEvent.flags.contains(.maskControl) && scrollEvent.dy != 0 {
-            handleAccessibilityZoom(dy: scrollEvent.dy)
+        if flags.contains(.maskControl) && dy != 0 {
+            handleAccessibilityZoom(dy: dy)
             return
         }
 
@@ -1403,7 +1410,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
     private func performScrollAction(_ keyCode: CGKeyCode) {
         let dy: CGFloat = keyCode == KeyCodeMapping.scrollUp ? 10 : -10
-        scroll(dx: 0, dy: dy, phase: nil, momentumPhase: nil, isContinuous: false, flags: [])
+        scroll(event: ScrollEvent(dx: 0, dy: dy))
     }
 
     // MARK: - Mouse Button Simulation

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
@@ -4,6 +4,15 @@ import AppKit
 import IOKit.hidsystem
 import ApplicationServices.HIServices
 
+struct ScrollEvent: Sendable, Equatable {
+    var dx: CGFloat
+    var dy: CGFloat
+    var phase: CGScrollPhase? = nil
+    var momentumPhase: CGMomentumScrollPhase? = nil
+    var isContinuous: Bool = false
+    var flags: CGEventFlags = []
+}
+
 protocol InputSimulatorProtocol: Sendable {
     func pressKey(_ keyCode: CGKeyCode, modifiers: CGEventFlags)
     func keyDown(_ keyCode: CGKeyCode, modifiers: CGEventFlags)
@@ -17,14 +26,7 @@ protocol InputSimulatorProtocol: Sendable {
     func moveMouseNative(dx: Int, dy: Int)
     func warpMouseTo(point: CGPoint)
     var isLeftMouseButtonHeld: Bool { get }
-    func scroll(
-        dx: CGFloat,
-        dy: CGFloat,
-        phase: CGScrollPhase?,
-        momentumPhase: CGMomentumScrollPhase?,
-        isContinuous: Bool,
-        flags: CGEventFlags
-    )
+    func scroll(event: ScrollEvent)
     func executeMapping(_ mapping: KeyMapping)
     func startHoldMapping(_ mapping: KeyMapping)
     func stopHoldMapping(_ mapping: KeyMapping)
@@ -33,7 +35,7 @@ protocol InputSimulatorProtocol: Sendable {
 
 extension InputSimulatorProtocol {
     func scroll(dx: CGFloat, dy: CGFloat) {
-        scroll(dx: dx, dy: dy, phase: nil, momentumPhase: nil, isContinuous: false, flags: [])
+        scroll(event: ScrollEvent(dx: dx, dy: dy))
     }
 }
 
@@ -1130,22 +1132,15 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
     private var hasShownZoomKeyboardShortcutWarning: Bool = false
 
     /// Scrolls by a delta
-    func scroll(
-        dx: CGFloat,
-        dy: CGFloat,
-        phase: CGScrollPhase?,
-        momentumPhase: CGMomentumScrollPhase?,
-        isContinuous: Bool,
-        flags: CGEventFlags
-    ) {
+    func scroll(event scrollEvent: ScrollEvent) {
         if shouldRelayUniversalControlAction(),
            UniversalControlMouseRelay.shared.sendScroll(
-                dx: dx,
-                dy: dy,
-                phase: phase,
-                momentumPhase: momentumPhase,
-                isContinuous: isContinuous,
-                flags: flags
+                dx: scrollEvent.dx,
+                dy: scrollEvent.dy,
+                phase: scrollEvent.phase,
+                momentumPhase: scrollEvent.momentumPhase,
+                isContinuous: scrollEvent.isContinuous,
+                flags: scrollEvent.flags
            ) {
             return
         }
@@ -1153,8 +1148,8 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         // Check if Control is held - if so, convert to Accessibility Zoom keyboard shortcuts
         // macOS Accessibility Zoom doesn't respond to synthetic Control+scroll events,
         // but does respond to Option+Command+Plus/Minus keyboard shortcuts
-        if flags.contains(.maskControl) && dy != 0 {
-            handleAccessibilityZoom(dy: dy)
+        if scrollEvent.flags.contains(.maskControl) && scrollEvent.dy != 0 {
+            handleAccessibilityZoom(dy: scrollEvent.dy)
             return
         }
 

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -2035,14 +2035,14 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
                   let momentumRaw = Int32(parts[4]),
                   let continuousRaw = Int(parts[5]),
                   let flagsRaw = UInt64(parts[6]) else { return }
-            input?.scroll(
+            input?.scroll(event: ScrollEvent(
                 dx: CGFloat(dx),
                 dy: CGFloat(dy),
                 phase: phaseRaw >= 0 ? CGScrollPhase(rawValue: UInt32(phaseRaw)) : nil,
                 momentumPhase: momentumRaw >= 0 ? CGMomentumScrollPhase(rawValue: UInt32(momentumRaw)) : nil,
                 isContinuous: continuousRaw != 0,
                 flags: CGEventFlags(rawValue: flagsRaw)
-            )
+            ))
             logFirstReceive("scroll dx=\(dx) dy=\(dy)")
         case "tt":
             guard parts.count == 4,

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/JoystickHandler.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/JoystickHandler.swift
@@ -515,12 +515,14 @@ extension MappingEngine {
         }
 
         inputSimulator.scroll(
-            dx: dx,
-            dy: dy,
-            phase: nil,
-            momentumPhase: nil,
-            isContinuous: false,
-            flags: inputSimulator.getHeldModifiers()
+            event: ScrollEvent(
+                dx: dx,
+                dy: dy,
+                phase: nil,
+                momentumPhase: nil,
+                isContinuous: false,
+                flags: inputSimulator.getHeldModifiers()
+            )
         )
         usageStatsService?.recordScrollDistance(dx: Double(dx), dy: Double(dy))
     }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/TouchpadInputHandler.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/TouchpadInputHandler.swift
@@ -126,13 +126,15 @@ extension MappingEngine {
         }
 
         inputSimulator.scroll(
-            dx: CGFloat(dx),
-            dy: CGFloat(dy),
-            phase: nil,
-            momentumPhase: nil,
-            isContinuous: false,
-            flags: inputSimulator.getHeldModifiers()
-        )
+                event: ScrollEvent(
+                    dx: CGFloat(dx),
+                    dy: CGFloat(dy),
+                    phase: nil,
+                    momentumPhase: nil,
+                    isContinuous: false,
+                    flags: inputSimulator.getHeldModifiers()
+                )
+            )
         usageStatsService?.recordScrollDistance(dx: dx, dy: dy)
     }
 
@@ -154,13 +156,15 @@ extension MappingEngine {
 		guard abs(dy) > 0.1 else { return }
 
 		inputSimulator.scroll(
-			dx: 0,
-			dy: CGFloat(dy),
-			phase: nil,
-			momentumPhase: nil,
-			isContinuous: false,
-			flags: inputSimulator.getHeldModifiers()
-		)
+                event: ScrollEvent(
+                    dx: 0,
+                    dy: CGFloat(dy),
+                    phase: nil,
+                    momentumPhase: nil,
+                    isContinuous: false,
+                    flags: inputSimulator.getHeldModifiers()
+                )
+            )
 		usageStatsService?.recordScrollDistance(dx: 0, dy: dy)
     }
 
@@ -312,6 +316,7 @@ extension MappingEngine {
 
             if wasActive {
                 inputSimulator.scroll(
+                event: ScrollEvent(
                     dx: 0,
                     dy: 0,
                     phase: .ended,
@@ -319,6 +324,7 @@ extension MappingEngine {
                     isContinuous: true,
                     flags: inputSimulator.getHeldModifiers()
                 )
+            )
             }
             state.lock.withLock {
                 // Transfer momentum candidate to active momentum velocity on finger lift.
@@ -378,12 +384,14 @@ extension MappingEngine {
 
         if phase == .began {
             inputSimulator.scroll(
-                dx: 0,
-                dy: 0,
-                phase: .began,
-                momentumPhase: nil,
-                isContinuous: true,
-                flags: inputSimulator.getHeldModifiers()
+                event: ScrollEvent(
+                    dx: 0,
+                    dy: 0,
+                    phase: .began,
+                    momentumPhase: nil,
+                    isContinuous: true,
+                    flags: inputSimulator.getHeldModifiers()
+                )
             )
         }
 
@@ -625,6 +633,7 @@ extension MappingEngine {
             residualY = combinedDy - sendDy
             if sendDx != 0 || sendDy != 0 {
                 inputSimulator.scroll(
+                event: ScrollEvent(
                     dx: CGFloat(sendDx),
                     dy: CGFloat(sendDy),
                     phase: .changed,
@@ -632,6 +641,7 @@ extension MappingEngine {
                     isContinuous: true,
                     flags: inputSimulator.getHeldModifiers()
                 )
+            )
                 usageStatsService?.recordScrollDistance(dx: sendDx, dy: sendDy)
             }
             state.lock.withLock {
@@ -651,6 +661,7 @@ extension MappingEngine {
         if idleInterval > Config.touchpadMomentumMaxIdleInterval {
             if wasActive {
                 inputSimulator.scroll(
+                event: ScrollEvent(
                     dx: 0,
                     dy: 0,
                     phase: nil,
@@ -658,6 +669,7 @@ extension MappingEngine {
                     isContinuous: true,
                     flags: inputSimulator.getHeldModifiers()
                 )
+            )
             }
             state.lock.withLock {
                 state.touchpadMomentumVelocity = .zero
@@ -676,6 +688,7 @@ extension MappingEngine {
         if speed < Config.touchpadMomentumStopVelocity {
             if wasActive {
                 inputSimulator.scroll(
+                event: ScrollEvent(
                     dx: 0,
                     dy: 0,
                     phase: nil,
@@ -683,6 +696,7 @@ extension MappingEngine {
                     isContinuous: true,
                     flags: inputSimulator.getHeldModifiers()
                 )
+            )
             }
             state.lock.withLock {
                 state.touchpadMomentumVelocity = .zero
@@ -706,12 +720,14 @@ extension MappingEngine {
         if sendDx != 0 || sendDy != 0 {
             let momentumPhase: CGMomentumScrollPhase = wasActive ? .continuous : .begin
             inputSimulator.scroll(
-                dx: CGFloat(sendDx),
-                dy: CGFloat(sendDy),
-                phase: nil,
-                momentumPhase: momentumPhase,
-                isContinuous: true,
-                flags: inputSimulator.getHeldModifiers()
+                event: ScrollEvent(
+                    dx: CGFloat(sendDx),
+                    dy: CGFloat(sendDy),
+                    phase: nil,
+                    momentumPhase: momentumPhase,
+                    isContinuous: true,
+                    flags: inputSimulator.getHeldModifiers()
+                )
             )
             wasActive = true
         }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/TouchpadInputHandler.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/TouchpadInputHandler.swift
@@ -126,15 +126,15 @@ extension MappingEngine {
         }
 
         inputSimulator.scroll(
-                event: ScrollEvent(
-                    dx: CGFloat(dx),
-                    dy: CGFloat(dy),
-                    phase: nil,
-                    momentumPhase: nil,
-                    isContinuous: false,
-                    flags: inputSimulator.getHeldModifiers()
-                )
+            event: ScrollEvent(
+                dx: CGFloat(dx),
+                dy: CGFloat(dy),
+                phase: nil,
+                momentumPhase: nil,
+                isContinuous: false,
+                flags: inputSimulator.getHeldModifiers()
             )
+        )
         usageStatsService?.recordScrollDistance(dx: dx, dy: dy)
     }
 
@@ -155,17 +155,17 @@ extension MappingEngine {
 		}
 		guard abs(dy) > 0.1 else { return }
 
-		inputSimulator.scroll(
-                event: ScrollEvent(
-                    dx: 0,
-                    dy: CGFloat(dy),
-                    phase: nil,
-                    momentumPhase: nil,
-                    isContinuous: false,
-                    flags: inputSimulator.getHeldModifiers()
-                )
+        inputSimulator.scroll(
+            event: ScrollEvent(
+                dx: 0,
+                dy: CGFloat(dy),
+                phase: nil,
+                momentumPhase: nil,
+                isContinuous: false,
+                flags: inputSimulator.getHeldModifiers()
             )
-		usageStatsService?.recordScrollDistance(dx: 0, dy: dy)
+        )
+        usageStatsService?.recordScrollDistance(dx: 0, dy: dy)
     }
 
     // MARK: - Touchpad Tap Gestures
@@ -316,15 +316,15 @@ extension MappingEngine {
 
             if wasActive {
                 inputSimulator.scroll(
-                event: ScrollEvent(
-                    dx: 0,
-                    dy: 0,
-                    phase: .ended,
-                    momentumPhase: nil,
-                    isContinuous: true,
-                    flags: inputSimulator.getHeldModifiers()
+                    event: ScrollEvent(
+                        dx: 0,
+                        dy: 0,
+                        phase: .ended,
+                        momentumPhase: nil,
+                        isContinuous: true,
+                        flags: inputSimulator.getHeldModifiers()
+                    )
                 )
-            )
             }
             state.lock.withLock {
                 // Transfer momentum candidate to active momentum velocity on finger lift.
@@ -633,15 +633,15 @@ extension MappingEngine {
             residualY = combinedDy - sendDy
             if sendDx != 0 || sendDy != 0 {
                 inputSimulator.scroll(
-                event: ScrollEvent(
-                    dx: CGFloat(sendDx),
-                    dy: CGFloat(sendDy),
-                    phase: .changed,
-                    momentumPhase: nil,
-                    isContinuous: true,
-                    flags: inputSimulator.getHeldModifiers()
+                    event: ScrollEvent(
+                        dx: CGFloat(sendDx),
+                        dy: CGFloat(sendDy),
+                        phase: .changed,
+                        momentumPhase: nil,
+                        isContinuous: true,
+                        flags: inputSimulator.getHeldModifiers()
+                    )
                 )
-            )
                 usageStatsService?.recordScrollDistance(dx: sendDx, dy: sendDy)
             }
             state.lock.withLock {
@@ -661,15 +661,15 @@ extension MappingEngine {
         if idleInterval > Config.touchpadMomentumMaxIdleInterval {
             if wasActive {
                 inputSimulator.scroll(
-                event: ScrollEvent(
-                    dx: 0,
-                    dy: 0,
-                    phase: nil,
-                    momentumPhase: .end,
-                    isContinuous: true,
-                    flags: inputSimulator.getHeldModifiers()
+                    event: ScrollEvent(
+                        dx: 0,
+                        dy: 0,
+                        phase: nil,
+                        momentumPhase: .end,
+                        isContinuous: true,
+                        flags: inputSimulator.getHeldModifiers()
+                    )
                 )
-            )
             }
             state.lock.withLock {
                 state.touchpadMomentumVelocity = .zero
@@ -688,15 +688,15 @@ extension MappingEngine {
         if speed < Config.touchpadMomentumStopVelocity {
             if wasActive {
                 inputSimulator.scroll(
-                event: ScrollEvent(
-                    dx: 0,
-                    dy: 0,
-                    phase: nil,
-                    momentumPhase: .end,
-                    isContinuous: true,
-                    flags: inputSimulator.getHeldModifiers()
+                    event: ScrollEvent(
+                        dx: 0,
+                        dy: 0,
+                        phase: nil,
+                        momentumPhase: .end,
+                        isContinuous: true,
+                        flags: inputSimulator.getHeldModifiers()
+                    )
                 )
-            )
             }
             state.lock.withLock {
                 state.touchpadMomentumVelocity = .zero

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptEditorSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptEditorSheet.swift
@@ -339,7 +339,7 @@ private class MockInputSimulator: InputSimulatorProtocol {
     func moveMouseNative(dx: Int, dy: Int) {}
     func warpMouseTo(point: CGPoint) {}
     var isLeftMouseButtonHeld: Bool { false }
-    func scroll(dx: CGFloat, dy: CGFloat, phase: CGScrollPhase?, momentumPhase: CGMomentumScrollPhase?, isContinuous: Bool, flags: CGEventFlags) {}
+    func scroll(event: ScrollEvent) {}
     func executeMapping(_ mapping: KeyMapping) {}
     func startHoldMapping(_ mapping: KeyMapping) {}
     func stopHoldMapping(_ mapping: KeyMapping) {}

--- a/XboxControllerMapper/XboxControllerMapperTests/InputSimulatorBugTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/InputSimulatorBugTests.swift
@@ -245,12 +245,12 @@ final class ZoomAccumulatorThreadSafetyTests: XCTestCase {
         DispatchQueue.concurrentPerform(iterations: iterations) { i in
             let dy = CGFloat(i % 2 == 0 ? 5 : -5)
             // The Control flag triggers the handleAccessibilityZoom path
-            simulator.scroll(
+            simulator.scroll(event: ScrollEvent(
                 dx: 0, dy: dy,
                 phase: nil, momentumPhase: nil,
                 isContinuous: false,
                 flags: .maskControl
-            )
+            ))
         }
 
         // No crash = success. The accumulator should be in a valid state.
@@ -265,11 +265,11 @@ final class ZoomAccumulatorThreadSafetyTests: XCTestCase {
 
         DispatchQueue.concurrentPerform(iterations: iterations) { i in
             if i % 3 == 0 {
-                simulator.scroll(dx: 0, dy: 5, phase: nil, momentumPhase: nil,
-                    isContinuous: false, flags: .maskControl)
+                simulator.scroll(event: ScrollEvent(dx: 0, dy: 5, phase: nil, momentumPhase: nil,
+                    isContinuous: false, flags: .maskControl))
             } else {
-                simulator.scroll(dx: 0, dy: 3, phase: nil, momentumPhase: nil,
-                    isContinuous: false, flags: [])
+                simulator.scroll(event: ScrollEvent(dx: 0, dy: 3, phase: nil, momentumPhase: nil,
+                    isContinuous: false, flags: []))
             }
         }
 
@@ -306,12 +306,12 @@ final class ZoomWarningStateMachineTests: XCTestCase {
         // Simulate many control+scroll calls (each increments zoomAttemptCount)
         // After 5 attempts, warning would be shown and shortcuts stop being sent.
         for _ in 0..<20 {
-            simulator.scroll(
+            simulator.scroll(event: ScrollEvent(
                 dx: 0, dy: 15, // Above threshold to trigger zoom step
                 phase: nil, momentumPhase: nil,
                 isContinuous: false,
                 flags: .maskControl
-            )
+            ))
             // Small delay to pass rate limiting
             usleep(60_000) // 60ms > 50ms minimum interval
         }

--- a/XboxControllerMapper/XboxControllerMapperTests/ScriptEngineSecurityTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ScriptEngineSecurityTests.swift
@@ -18,7 +18,7 @@ private class StubInputSimulator: InputSimulatorProtocol {
     func moveMouseNative(dx: Int, dy: Int) {}
     func warpMouseTo(point: CGPoint) {}
     var isLeftMouseButtonHeld: Bool { false }
-    func scroll(dx: CGFloat, dy: CGFloat, phase: CGScrollPhase?, momentumPhase: CGMomentumScrollPhase?, isContinuous: Bool, flags: CGEventFlags) {}
+    func scroll(event: ScrollEvent) {}
     func executeMapping(_ mapping: KeyMapping) {}
     func startHoldMapping(_ mapping: KeyMapping) {}
     func stopHoldMapping(_ mapping: KeyMapping) {}

--- a/XboxControllerMapper/XboxControllerMapperTests/ScriptExamplesTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ScriptExamplesTests.swift
@@ -176,7 +176,7 @@ private class StubScriptInputSimulator: InputSimulatorProtocol {
     func moveMouseNative(dx: Int, dy: Int) {}
     func warpMouseTo(point: CGPoint) {}
     var isLeftMouseButtonHeld: Bool { false }
-    func scroll(dx: CGFloat, dy: CGFloat, phase: CGScrollPhase?, momentumPhase: CGMomentumScrollPhase?, isContinuous: Bool, flags: CGEventFlags) {}
+    func scroll(event: ScrollEvent) {}
     func executeMapping(_ mapping: KeyMapping) {}
     func startHoldMapping(_ mapping: KeyMapping) {}
     func stopHoldMapping(_ mapping: KeyMapping) {}

--- a/XboxControllerMapper/XboxControllerMapperTests/XboxControllerMapperTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/XboxControllerMapperTests.swift
@@ -167,17 +167,10 @@ class MockInputSimulator: InputSimulatorProtocol {
         lastWarpPoint = point
     }
 
-    func scroll(
-        dx: CGFloat,
-        dy: CGFloat,
-        phase: CGScrollPhase?,
-        momentumPhase: CGMomentumScrollPhase?,
-        isContinuous: Bool,
-        flags: CGEventFlags
-    ) {
+    func scroll(event scrollEvent: ScrollEvent) {
         lock.lock()
         defer { lock.unlock() }
-        _events.append(.scroll(dx, dy))
+        _events.append(.scroll(scrollEvent.dx, scrollEvent.dy))
     }
     
     func executeMapping(_ mapping: KeyMapping) {
@@ -1394,7 +1387,7 @@ final class XboxControllerMapperTests: XCTestCase {
         // For now, verify scroll mock exists and events can be recorded
         await MainActor.run {
             // The mock should be able to receive scroll events
-            mockInputSimulator.scroll(dx: 1.0, dy: 2.0, phase: nil, momentumPhase: nil, isContinuous: false, flags: [])
+            mockInputSimulator.scroll(event: ScrollEvent(dx: 1.0, dy: 2.0, phase: nil, momentumPhase: nil, isContinuous: false, flags: []))
         }
 
         await MainActor.run {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is reducing the number of parameters in the `scroll` function in `InputSimulatorProtocol` and its implementations. A `ScrollEvent` struct was created to encapsulate all the scrolling parameters.
💡 **Why:** Having 6 parameters in a function makes it difficult to read and maintain, especially since many are optional or have standard default values. Encapsulating them into a `ScrollEvent` struct makes call sites cleaner and allows extending the struct easily in the future without changing function signatures everywhere.
✅ **Verification:** Replaced all usages across the codebase correctly and carefully using a combination of targeted string replacement and manual verification. Verified that `MockInputSimulator` instances in tests are updated properly. Requested a code review which passed with #Correct#. Tests cannot be run in the sandbox environment as it's missing Xcode build tools but statically verified.
✨ **Result:** Improved maintainability and reduced cognitive load when calling or implementing the `scroll` functionality.

---
*PR created automatically by Jules for task [9769154049622428754](https://jules.google.com/task/9769154049622428754) started by @NSEvent*