### PR TITLE
feat: distinguish left/right modifier keys in mappings

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Models/KeyMapping.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Models/KeyMapping.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreGraphics
+import Carbon.HIToolbox
 
 // MARK: - KeyBindingRepresentable Protocol
 
@@ -116,10 +117,10 @@ extension KeyBindingRepresentable {
     var displayString: String {
         var parts: [String] = []
 
-        if modifiers.command { parts.append("⌘") }
-        if modifiers.option { parts.append("⌥") }
-        if modifiers.shift { parts.append("⇧") }
-        if modifiers.control { parts.append("⌃") }
+        if modifiers.command { parts.append(ModifierFlags.label(for: modifiers.commandSide) + "⌘") }
+        if modifiers.option { parts.append(ModifierFlags.label(for: modifiers.optionSide) + "⌥") }
+        if modifiers.shift { parts.append(ModifierFlags.label(for: modifiers.shiftSide) + "⇧") }
+        if modifiers.control { parts.append(ModifierFlags.label(for: modifiers.controlSide) + "⌃") }
 
         if let keyCode = keyCode {
             parts.append(KeyCodeMapping.displayName(for: keyCode))
@@ -257,10 +258,10 @@ struct KeyMapping: Codable, Equatable, ExecutableAction {
 
         var parts: [String] = []
 
-        if modifiers.command { parts.append("⌘") }
-        if modifiers.option { parts.append("⌥") }
-        if modifiers.shift { parts.append("⇧") }
-        if modifiers.control { parts.append("⌃") }
+        if modifiers.command { parts.append(ModifierFlags.label(for: modifiers.commandSide) + "⌘") }
+        if modifiers.option { parts.append(ModifierFlags.label(for: modifiers.optionSide) + "⌥") }
+        if modifiers.shift { parts.append(ModifierFlags.label(for: modifiers.shiftSide) + "⇧") }
+        if modifiers.control { parts.append(ModifierFlags.label(for: modifiers.controlSide) + "⌃") }
 
         if let keyCode = keyCode {
             parts.append(KeyCodeMapping.displayName(for: keyCode))
@@ -383,10 +384,10 @@ struct LongHoldMapping: Codable, Equatable, ExecutableAction {
             return "Script"
         }
         var parts: [String] = []
-        if modifiers.command { parts.append("⌘") }
-        if modifiers.option { parts.append("⌥") }
-        if modifiers.shift { parts.append("⇧") }
-        if modifiers.control { parts.append("⌃") }
+        if modifiers.command { parts.append(ModifierFlags.label(for: modifiers.commandSide) + "⌘") }
+        if modifiers.option { parts.append(ModifierFlags.label(for: modifiers.optionSide) + "⌥") }
+        if modifiers.shift { parts.append(ModifierFlags.label(for: modifiers.shiftSide) + "⇧") }
+        if modifiers.control { parts.append(ModifierFlags.label(for: modifiers.controlSide) + "⌃") }
         if let keyCode = keyCode {
             parts.append(KeyCodeMapping.displayName(for: keyCode))
         } else if parts.isEmpty {
@@ -470,10 +471,10 @@ struct DoubleTapMapping: Codable, Equatable, ExecutableAction {
             return "Script"
         }
         var parts: [String] = []
-        if modifiers.command { parts.append("⌘") }
-        if modifiers.option { parts.append("⌥") }
-        if modifiers.shift { parts.append("⇧") }
-        if modifiers.control { parts.append("⌃") }
+        if modifiers.command { parts.append(ModifierFlags.label(for: modifiers.commandSide) + "⌘") }
+        if modifiers.option { parts.append(ModifierFlags.label(for: modifiers.optionSide) + "⌥") }
+        if modifiers.shift { parts.append(ModifierFlags.label(for: modifiers.shiftSide) + "⇧") }
+        if modifiers.control { parts.append(ModifierFlags.label(for: modifiers.controlSide) + "⌃") }
         if let keyCode = keyCode {
             parts.append(KeyCodeMapping.displayName(for: keyCode))
         } else if parts.isEmpty {
@@ -538,6 +539,14 @@ struct RepeatMapping: Codable, Equatable {
     }
 }
 
+/// Identifies which physical side of a modifier key to press.
+/// When nil on `ModifierFlags`, the modifier is treated generically (the OS sees
+/// `.maskCommand` regardless and the simulator pre-presses the Left keycode).
+enum ModifierSide: String, Codable, Equatable {
+    case left
+    case right
+}
+
 /// Represents modifier key flags in a Codable-friendly way
 struct ModifierFlags: Codable, Equatable {
     var command: Bool = false
@@ -545,8 +554,17 @@ struct ModifierFlags: Codable, Equatable {
     var shift: Bool = false
     var control: Bool = false
 
+    /// Optional left/right side for each modifier. nil means "either side" —
+    /// the simulator presses the Left keycode by default. Only meaningful when
+    /// the corresponding modifier flag is true.
+    var commandSide: ModifierSide?
+    var optionSide: ModifierSide?
+    var shiftSide: ModifierSide?
+    var controlSide: ModifierSide?
+
     private enum CodingKeys: String, CodingKey {
         case command, option, shift, control
+        case commandSide, optionSide, shiftSide, controlSide
     }
 
     init(from decoder: Decoder) throws {
@@ -555,20 +573,39 @@ struct ModifierFlags: Codable, Equatable {
         option = try container.decode(.option, default: false)
         shift = try container.decode(.shift, default: false)
         control = try container.decode(.control, default: false)
+        commandSide = try container.decodeIfPresent(ModifierSide.self, forKey: .commandSide)
+        optionSide = try container.decodeIfPresent(ModifierSide.self, forKey: .optionSide)
+        shiftSide = try container.decodeIfPresent(ModifierSide.self, forKey: .shiftSide)
+        controlSide = try container.decodeIfPresent(ModifierSide.self, forKey: .controlSide)
     }
 
-    init(command: Bool = false, option: Bool = false, shift: Bool = false, control: Bool = false) {
+    init(
+        command: Bool = false,
+        option: Bool = false,
+        shift: Bool = false,
+        control: Bool = false,
+        commandSide: ModifierSide? = nil,
+        optionSide: ModifierSide? = nil,
+        shiftSide: ModifierSide? = nil,
+        controlSide: ModifierSide? = nil
+    ) {
         self.command = command
         self.option = option
         self.shift = shift
         self.control = control
+        self.commandSide = commandSide
+        self.optionSide = optionSide
+        self.shiftSide = shiftSide
+        self.controlSide = controlSide
     }
 
     var hasAny: Bool {
         command || option || shift || control
     }
 
-    /// Convert to CGEventFlags
+    /// Convert to CGEventFlags. The mask is the same regardless of side — at the OS
+    /// flag level, Left and Right ⌘ both set `.maskCommand`. Side only affects which
+    /// virtualKey the simulator pre-presses (see `virtualKey(forMask:)`).
     var cgEventFlags: CGEventFlags {
         var flags: CGEventFlags = []
         if command { flags.insert(.maskCommand) }
@@ -578,8 +615,34 @@ struct ModifierFlags: Codable, Equatable {
         return flags
     }
 
+    /// Returns the side-specific virtual keycode for a modifier mask. Defaults to the
+    /// Left variant when no side was selected. Returns nil for non-modifier masks.
+    func virtualKey(forMask mask: CGEventFlags) -> CGKeyCode? {
+        switch mask {
+        case .maskCommand:
+            return CGKeyCode(commandSide == .right ? kVK_RightCommand : kVK_Command)
+        case .maskAlternate:
+            return CGKeyCode(optionSide == .right ? kVK_RightOption : kVK_Option)
+        case .maskShift:
+            return CGKeyCode(shiftSide == .right ? kVK_RightShift : kVK_Shift)
+        case .maskControl:
+            return CGKeyCode(controlSide == .right ? kVK_RightControl : kVK_Control)
+        default:
+            return nil
+        }
+    }
+
     static let command = ModifierFlags(command: true)
     static let option = ModifierFlags(option: true)
     static let shift = ModifierFlags(shift: true)
     static let control = ModifierFlags(control: true)
+
+    /// "L" / "R" prefix string for modifier display, or empty when no side is set.
+    static func label(for side: ModifierSide?) -> String {
+        switch side {
+        case .left: return "L"
+        case .right: return "R"
+        case .none: return ""
+        }
+    }
 }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
@@ -14,6 +14,8 @@ protocol InputSimulatorProtocol: Sendable {
     func keyUp(_ keyCode: CGKeyCode)
     func holdModifier(_ modifier: CGEventFlags)
     func releaseModifier(_ modifier: CGEventFlags)
+    func holdModifierKey(_ keyCode: CGKeyCode)
+    func releaseModifierKey(_ keyCode: CGKeyCode)
     func releaseAllModifiers()
     func isHoldingModifiers(_ modifier: CGEventFlags) -> Bool
     func getHeldModifiers() -> CGEventFlags
@@ -45,6 +47,30 @@ extension InputSimulatorProtocol {
     func pressKey(_ keyCode: CGKeyCode, modifiers: ModifierFlags) {
         pressKey(keyCode, modifiers: modifiers.cgEventFlags)
     }
+
+    func holdModifierKey(_ keyCode: CGKeyCode) {
+		holdModifier(KeyCodeMapping.modifierFlag(for: keyCode))
+    }
+
+    func releaseModifierKey(_ keyCode: CGKeyCode) {
+		releaseModifier(KeyCodeMapping.modifierFlag(for: keyCode))
+    }
+
+    func holdModifiers(_ modifiers: ModifierFlags) {
+		for mask in ModifierKeyState.modifierPressOrder where modifiers.cgEventFlags.contains(mask) {
+			if let keyCode = modifiers.virtualKey(forMask: mask) {
+				holdModifierKey(keyCode)
+			}
+		}
+    }
+
+    func releaseModifiers(_ modifiers: ModifierFlags) {
+		for mask in ModifierKeyState.modifierReleaseOrder where modifiers.cgEventFlags.contains(mask) {
+			if let keyCode = modifiers.virtualKey(forMask: mask) {
+				releaseModifierKey(keyCode)
+			}
+		}
+    }
 }
 
 // MARK: - Modifier Key Handler
@@ -62,6 +88,14 @@ private class ModifierKeyState {
     /// List of modifier masks in order for iteration
     static let modifierMasks: [CGEventFlags] = [
         .maskCommand, .maskAlternate, .maskShift, .maskControl
+    ]
+
+    static let modifierPressOrder: [CGEventFlags] = [
+		.maskCommand, .maskShift, .maskAlternate, .maskControl
+    ]
+
+    static let modifierReleaseOrder: [CGEventFlags] = [
+		.maskControl, .maskAlternate, .maskShift, .maskCommand
     ]
 }
 
@@ -238,7 +272,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
     private func pressKeyInternal(_ keyCode: CGKeyCode, modifiers: CGEventFlags, modifierSides: ModifierFlags?) {
         LatencyDiagnostics.mark("input.pressKey \(keyCode)")
         if shouldRelayUniversalControlAction(),
-           UniversalControlMouseRelay.shared.sendKeyPress(keyCode, modifiers: modifiers) {
+		   sendUniversalControlKeyPress(keyCode, modifiers: modifiers, modifierSides: modifierSides) {
             return
         }
 
@@ -330,6 +364,17 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
             print("  ✅ Key sequence completed")
             #endif
         }
+    }
+
+    private func sendUniversalControlKeyPress(
+		_ keyCode: CGKeyCode,
+		modifiers: CGEventFlags,
+		modifierSides: ModifierFlags?
+    ) -> Bool {
+		if let modifierSides {
+			return UniversalControlMouseRelay.shared.sendKeyPress(keyCode, modifiers: modifierSides)
+		}
+		return UniversalControlMouseRelay.shared.sendKeyPress(keyCode, modifiers: modifiers)
     }
 
     /// Posts a single key event
@@ -2007,10 +2052,9 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
             }
         } else if mapping.modifiers.hasAny {
             // Modifier-only mapping - tap the modifiers
-            let flags = mapping.modifiers.cgEventFlags
-            holdModifier(flags)
+			holdModifiers(mapping.modifiers)
             DispatchQueue.main.asyncAfter(deadline: .now() + Config.modifierReleaseCheckDelay) { [weak self] in
-                self?.releaseModifier(flags)
+				self?.releaseModifiers(mapping.modifiers)
             }
         }
     }
@@ -2019,7 +2063,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
     func startHoldMapping(_ mapping: KeyMapping) {
         // Hold any modifiers
         if mapping.modifiers.hasAny {
-            holdModifier(mapping.modifiers.cgEventFlags)
+			holdModifiers(mapping.modifiers)
         }
         // Hold the key/mouse button
         if let keyCode = mapping.keyCode {
@@ -2043,7 +2087,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         }
         // Then release modifiers
         if mapping.modifiers.hasAny {
-            releaseModifier(mapping.modifiers.cgEventFlags)
+			releaseModifiers(mapping.modifiers)
         }
     }
 

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
@@ -6,6 +6,10 @@ import ApplicationServices.HIServices
 
 protocol InputSimulatorProtocol: Sendable {
     func pressKey(_ keyCode: CGKeyCode, modifiers: CGEventFlags)
+    /// Side-aware variant of `pressKey` — the simulator picks the Left/Right
+    /// modifier virtualKey based on `ModifierFlags.{command,option,shift,control}Side`.
+    /// Default implementation falls back to the flag-only path.
+    func pressKey(_ keyCode: CGKeyCode, modifiers: ModifierFlags)
     func keyDown(_ keyCode: CGKeyCode, modifiers: CGEventFlags)
     func keyUp(_ keyCode: CGKeyCode)
     func holdModifier(_ modifier: CGEventFlags)
@@ -34,6 +38,12 @@ protocol InputSimulatorProtocol: Sendable {
 extension InputSimulatorProtocol {
     func scroll(dx: CGFloat, dy: CGFloat) {
         scroll(dx: dx, dy: dy, phase: nil, momentumPhase: nil, isContinuous: false, flags: [])
+    }
+
+    /// Default implementation — conformers that don't care about L/R side fall back
+    /// to the flag-only path. `InputSimulator` overrides this with a side-aware impl.
+    func pressKey(_ keyCode: CGKeyCode, modifiers: ModifierFlags) {
+        pressKey(keyCode, modifiers: modifiers.cgEventFlags)
     }
 }
 
@@ -202,6 +212,30 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
     /// Simulates a key press with optional modifiers
     func pressKey(_ keyCode: CGKeyCode, modifiers: CGEventFlags = []) {
+        pressKeyInternal(keyCode, modifiers: modifiers, modifierSides: nil)
+    }
+
+    /// Side-aware variant — picks Left/Right modifier virtualKeys per `ModifierFlags`.
+    func pressKey(_ keyCode: CGKeyCode, modifiers: ModifierFlags) {
+        pressKeyInternal(keyCode, modifiers: modifiers.cgEventFlags, modifierSides: modifiers)
+    }
+
+    /// Picks the modifier pre-press keycode for a given mask. Honors `modifierSides`
+    /// when supplied; otherwise defaults to the Left variant (existing behavior).
+    private static func modifierVirtualKey(for mask: CGEventFlags, sides: ModifierFlags?) -> Int {
+        if let sides, let keyCode = sides.virtualKey(forMask: mask) {
+            return Int(keyCode)
+        }
+        switch mask {
+        case .maskCommand: return kVK_Command
+        case .maskAlternate: return kVK_Option
+        case .maskShift: return kVK_Shift
+        case .maskControl: return kVK_Control
+        default: return 0
+        }
+    }
+
+    private func pressKeyInternal(_ keyCode: CGKeyCode, modifiers: CGEventFlags, modifierSides: ModifierFlags?) {
         LatencyDiagnostics.mark("input.pressKey \(keyCode)")
         if shouldRelayUniversalControlAction(),
            UniversalControlMouseRelay.shared.sendKeyPress(keyCode, modifiers: modifiers) {
@@ -249,18 +283,19 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
             var currentFlags = startingFlags
 
-            // Helper to press modifier
-            func pressMod(_ key: Int, flag: CGEventFlags) {
+            // Helper to press modifier (side-aware via modifierSides)
+            func pressMod(flag: CGEventFlags) {
+                let key = InputSimulator.modifierVirtualKey(for: flag, sides: modifierSides)
                 currentFlags.insert(flag)
                 self.postKeyEvent(keyCode: CGKeyCode(key), keyDown: true, flags: currentFlags)
                 usleep(Config.modifierPressDelay)
             }
 
             // Press modifier keys first (Command -> Shift -> Option -> Control)
-            if modifiersToPress.contains(.maskCommand) { pressMod(kVK_Command, flag: .maskCommand) }
-            if modifiersToPress.contains(.maskShift)   { pressMod(kVK_Shift,   flag: .maskShift) }
-            if modifiersToPress.contains(.maskAlternate){ pressMod(kVK_Option,  flag: .maskAlternate) }
-            if modifiersToPress.contains(.maskControl) { pressMod(kVK_Control, flag: .maskControl) }
+            if modifiersToPress.contains(.maskCommand) { pressMod(flag: .maskCommand) }
+            if modifiersToPress.contains(.maskShift)   { pressMod(flag: .maskShift) }
+            if modifiersToPress.contains(.maskAlternate){ pressMod(flag: .maskAlternate) }
+            if modifiersToPress.contains(.maskControl) { pressMod(flag: .maskControl) }
 
             // Small delay after modifiers
             if !modifiersToPress.isEmpty {
@@ -277,18 +312,19 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
                 usleep(Config.preReleaseDelay)
             }
 
-            // Helper to release modifier
-            func releaseMod(_ key: Int, flag: CGEventFlags) {
+            // Helper to release modifier (side-aware — must match what we pressed)
+            func releaseMod(flag: CGEventFlags) {
+                let key = InputSimulator.modifierVirtualKey(for: flag, sides: modifierSides)
                 currentFlags.remove(flag)
                 self.postKeyEvent(keyCode: CGKeyCode(key), keyDown: false, flags: currentFlags)
                 usleep(Config.modifierPressDelay)
             }
 
             // Release modifier keys (Control -> Option -> Shift -> Command)
-            if modifiersToPress.contains(.maskControl) { releaseMod(kVK_Control, flag: .maskControl) }
-            if modifiersToPress.contains(.maskAlternate){ releaseMod(kVK_Option,  flag: .maskAlternate) }
-            if modifiersToPress.contains(.maskShift)   { releaseMod(kVK_Shift,   flag: .maskShift) }
-            if modifiersToPress.contains(.maskCommand) { releaseMod(kVK_Command, flag: .maskCommand) }
+            if modifiersToPress.contains(.maskControl) { releaseMod(flag: .maskControl) }
+            if modifiersToPress.contains(.maskAlternate){ releaseMod(flag: .maskAlternate) }
+            if modifiersToPress.contains(.maskShift)   { releaseMod(flag: .maskShift) }
+            if modifiersToPress.contains(.maskCommand) { releaseMod(flag: .maskCommand) }
 
             #if DEBUG
             print("  ✅ Key sequence completed")
@@ -1965,8 +2001,9 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
                     self?.releaseModifierKey(keyCode)
                 }
             } else {
-                // For any mapping with a key code, do a full press (handles both regular keys and mouse buttons)
-                pressKey(keyCode, modifiers: mapping.modifiers.cgEventFlags)
+                // For any mapping with a key code, do a full press (handles both regular keys and mouse buttons).
+                // Use the side-aware variant so the L/R modifier side selection on the mapping is honored.
+                pressKey(keyCode, modifiers: mapping.modifiers)
             }
         } else if mapping.modifiers.hasAny {
             // Modifier-only mapping - tap the modifiers

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
@@ -307,7 +307,17 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         // Add special flags for arrow keys, function keys, etc.
         // These flags (Fn, NumPad) are required for apps like Rectangle to recognize shortcuts
         let specialFlags = specialKeyFlags(for: keyCode)
-        let combinedFlags = flags.union(specialFlags)
+        var combinedFlags = flags.union(specialFlags)
+
+        // When posting a modifier key itself (left/right Command, Option, Shift, Control),
+        // the key-down event must carry its own modifier flag for macOS to register the key.
+        // Posting kVK_Command without .maskCommand causes the OS to drop the modifier state.
+        if keyDown {
+            let ownFlag = KeyCodeMapping.modifierFlag(for: keyCode)
+            if !ownFlag.isEmpty {
+                combinedFlags.insert(ownFlag)
+            }
+        }
 
         // Always set flags explicitly to override any inherited state from the event source
         // (e.g., prevents Fn/Globe key from being inherited from HID system state)
@@ -473,6 +483,91 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
                         NSLog("[InputSimulator] Failed to create modifier key-up event for mask 0x%llx - check Accessibility permissions", key)
                     }
                 }
+            }
+        }
+    }
+
+    /// Holds a specific modifier key, preserving left/right side identity.
+    ///
+    /// Unlike `holdModifier(_:)` which takes a mask (so Left and Right Command collapse
+    /// to `.maskCommand`), this posts the exact virtualKey passed in — so a button mapped
+    /// to Right Command will actually emit kVK_RightCommand events to the OS.
+    ///
+    /// The internal reference count is keyed by mask, so holding Left Cmd then Right Cmd
+    /// only emits one key-down. This matches the way modifier flags work at the OS level.
+    func holdModifierKey(_ keyCode: CGKeyCode) {
+        let mask = KeyCodeMapping.modifierFlag(for: keyCode)
+        guard !mask.isEmpty else { return }
+
+        if shouldRelayUniversalControlAction(),
+           UniversalControlMouseRelay.shared.sendKeyDown(keyCode, modifiers: []) {
+            // Remote side runs the same key-down path and will add the modifier flag
+            // in postKeyEvent. Track locally so getHeldModifiers stays consistent.
+            recordHeldModifier(mask)
+            return
+        }
+
+        guard checkAccessibility() else { return }
+        guard let source = eventSource else { return }
+
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        let key = mask.rawValue
+        let count = modifierCounts[key] ?? 0
+        modifierCounts[key] = count + 1
+
+        if count == 0 {
+            heldModifiers.insert(mask)
+            if let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true) {
+                event.flags = heldModifiers
+                event.post(tap: .cghidEventTap)
+            } else {
+                NSLog("[InputSimulator] Failed to create modifier key-down event for keyCode %d - check Accessibility permissions", keyCode)
+            }
+        }
+    }
+
+    /// Releases a previously held specific modifier key, preserving left/right side identity.
+    func releaseModifierKey(_ keyCode: CGKeyCode) {
+        let mask = KeyCodeMapping.modifierFlag(for: keyCode)
+        guard !mask.isEmpty else { return }
+
+        if shouldRelayUniversalControlAction(),
+           UniversalControlMouseRelay.shared.sendKeyUp(keyCode) {
+            recordReleasedModifier(mask)
+            return
+        }
+
+        guard checkAccessibility() else { return }
+        guard let source = eventSource else { return }
+
+        stateLock.lock()
+        defer { stateLock.unlock() }
+
+        let key = mask.rawValue
+        let count = modifierCounts[key] ?? 0
+        guard count > 0 else {
+            // Underflow protection — mirrors releaseModifier behavior
+            if heldModifiers.contains(mask) {
+                NSLog("[InputSimulator] WARNING: modifier 0x%llx in heldModifiers but count is 0 — force-removing to prevent stuck modifier", key)
+                heldModifiers.remove(mask)
+                if let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) {
+                    event.flags = heldModifiers
+                    event.post(tap: .cghidEventTap)
+                }
+            }
+            return
+        }
+        modifierCounts[key] = count - 1
+
+        if count == 1 {
+            heldModifiers.remove(mask)
+            if let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) {
+                event.flags = heldModifiers
+                event.post(tap: .cghidEventTap)
+            } else {
+                NSLog("[InputSimulator] Failed to create modifier key-up event for keyCode %d - check Accessibility permissions", keyCode)
             }
         }
     }
@@ -1862,8 +1957,17 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         #endif
 
         if let keyCode = mapping.keyCode {
-            // For any mapping with a key code, do a full press (handles both regular keys and mouse buttons)
-            pressKey(keyCode, modifiers: mapping.modifiers.cgEventFlags)
+            if KeyCodeMapping.isModifierKey(keyCode) {
+                // Tap a modifier key with left/right side preserved.
+                // Hold + delayed release matches the modifier-only mapping path below.
+                holdModifierKey(keyCode)
+                DispatchQueue.main.asyncAfter(deadline: .now() + Config.modifierReleaseCheckDelay) { [weak self] in
+                    self?.releaseModifierKey(keyCode)
+                }
+            } else {
+                // For any mapping with a key code, do a full press (handles both regular keys and mouse buttons)
+                pressKey(keyCode, modifiers: mapping.modifiers.cgEventFlags)
+            }
         } else if mapping.modifiers.hasAny {
             // Modifier-only mapping - tap the modifiers
             let flags = mapping.modifiers.cgEventFlags
@@ -1882,7 +1986,11 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         }
         // Hold the key/mouse button
         if let keyCode = mapping.keyCode {
-            keyDown(keyCode, modifiers: mapping.modifiers.cgEventFlags)
+            if KeyCodeMapping.isModifierKey(keyCode) {
+                holdModifierKey(keyCode)
+            } else {
+                keyDown(keyCode, modifiers: mapping.modifiers.cgEventFlags)
+            }
         }
     }
 
@@ -1890,7 +1998,11 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
     func stopHoldMapping(_ mapping: KeyMapping) {
         // Release the key/mouse button first
         if let keyCode = mapping.keyCode {
-            keyUp(keyCode)
+            if KeyCodeMapping.isModifierKey(keyCode) {
+                releaseModifierKey(keyCode)
+            } else {
+                keyUp(keyCode)
+            }
         }
         // Then release modifiers
         if mapping.modifiers.hasAny {

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
@@ -223,6 +223,12 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         CGEventFlags.maskControl.rawValue: 0
     ]
 
+    /// The exact physical modifier key currently posted for each mask.
+    /// Counts stay mask-based for overlap semantics, but key-up must mirror
+    /// the original left/right virtual key or side-aware remappers can see
+    /// an unmatched key-down.
+    private var modifierHeldKeyCodes: [UInt64: CGKeyCode] = [:]
+
     /// Track if we've warned about accessibility
     private var hasWarnedAboutAccessibility = false
 
@@ -507,6 +513,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
                 // First time this modifier is being held
                 heldModifiers.insert(mask)
                 if let vKey = ModifierKeyState.maskToKeyCode[key] {
+					modifierHeldKeyCodes[key] = CGKeyCode(vKey)
                     if let event = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(vKey), keyDown: true) {
                         event.flags = heldModifiers
                         event.post(tap: .cghidEventTap)
@@ -542,8 +549,10 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
                 if heldModifiers.contains(mask) {
                     NSLog("[InputSimulator] WARNING: modifier 0x%llx in heldModifiers but count is 0 — force-removing to prevent stuck modifier", key)
                     heldModifiers.remove(mask)
-                    if let vKey = ModifierKeyState.maskToKeyCode[key] {
-                        if let event = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(vKey), keyDown: false) {
+					let releaseKeyCode = modifierHeldKeyCodes[key] ?? ModifierKeyState.maskToKeyCode[key].map(CGKeyCode.init)
+					modifierHeldKeyCodes[key] = nil
+					if let releaseKeyCode {
+						if let event = CGEvent(keyboardEventSource: source, virtualKey: releaseKeyCode, keyDown: false) {
                             event.flags = heldModifiers
                             event.post(tap: .cghidEventTap)
                         }
@@ -556,8 +565,10 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
             if count == 1 {
                 // Last button holding this modifier released
                 heldModifiers.remove(mask)
-                if let vKey = ModifierKeyState.maskToKeyCode[key] {
-                    if let event = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(vKey), keyDown: false) {
+				let releaseKeyCode = modifierHeldKeyCodes[key] ?? ModifierKeyState.maskToKeyCode[key].map(CGKeyCode.init)
+				modifierHeldKeyCodes[key] = nil
+				if let releaseKeyCode {
+					if let event = CGEvent(keyboardEventSource: source, virtualKey: releaseKeyCode, keyDown: false) {
                         event.flags = heldModifiers
                         event.post(tap: .cghidEventTap)
                     } else {
@@ -575,7 +586,8 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
     /// to Right Command will actually emit kVK_RightCommand events to the OS.
     ///
     /// The internal reference count is keyed by mask, so holding Left Cmd then Right Cmd
-    /// only emits one key-down. This matches the way modifier flags work at the OS level.
+    /// only emits one key-down. The first physical keycode is remembered and released
+    /// when the final reference ends.
     func holdModifierKey(_ keyCode: CGKeyCode) {
         let mask = KeyCodeMapping.modifierFlag(for: keyCode)
         guard !mask.isEmpty else { return }
@@ -584,7 +596,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
            UniversalControlMouseRelay.shared.sendKeyDown(keyCode, modifiers: []) {
             // Remote side runs the same key-down path and will add the modifier flag
             // in postKeyEvent. Track locally so getHeldModifiers stays consistent.
-            recordHeldModifier(mask)
+			recordHeldModifierKey(keyCode)
             return
         }
 
@@ -600,6 +612,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
         if count == 0 {
             heldModifiers.insert(mask)
+			modifierHeldKeyCodes[key] = keyCode
             if let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true) {
                 event.flags = heldModifiers
                 event.post(tap: .cghidEventTap)
@@ -633,7 +646,9 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
             if heldModifiers.contains(mask) {
                 NSLog("[InputSimulator] WARNING: modifier 0x%llx in heldModifiers but count is 0 — force-removing to prevent stuck modifier", key)
                 heldModifiers.remove(mask)
-                if let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) {
+				let releaseKeyCode = modifierHeldKeyCodes[key] ?? keyCode
+				modifierHeldKeyCodes[key] = nil
+				if let event = CGEvent(keyboardEventSource: source, virtualKey: releaseKeyCode, keyDown: false) {
                     event.flags = heldModifiers
                     event.post(tap: .cghidEventTap)
                 }
@@ -644,7 +659,9 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
         if count == 1 {
             heldModifiers.remove(mask)
-            if let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) {
+			let releaseKeyCode = modifierHeldKeyCodes[key] ?? keyCode
+			modifierHeldKeyCodes[key] = nil
+			if let event = CGEvent(keyboardEventSource: source, virtualKey: releaseKeyCode, keyDown: false) {
                 event.flags = heldModifiers
                 event.post(tap: .cghidEventTap)
             } else {
@@ -686,8 +703,10 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         for mask in ModifierKeyState.modifierMasks where heldModifiers.contains(mask) {
             let key = mask.rawValue
             heldModifiers.remove(mask)
-            if let vKey = ModifierKeyState.maskToKeyCode[key] {
-                if let event = CGEvent(keyboardEventSource: source, virtualKey: CGKeyCode(vKey), keyDown: false) {
+			let releaseKeyCode = modifierHeldKeyCodes[key] ?? ModifierKeyState.maskToKeyCode[key].map(CGKeyCode.init)
+			modifierHeldKeyCodes[key] = nil
+			if let releaseKeyCode {
+				if let event = CGEvent(keyboardEventSource: source, virtualKey: releaseKeyCode, keyDown: false) {
                     event.flags = heldModifiers
                     event.post(tap: .cghidEventTap)
                 } else {
@@ -700,6 +719,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         for key in modifierCounts.keys {
             modifierCounts[key] = 0
         }
+		modifierHeldKeyCodes.removeAll()
         heldModifiers = []
     }
 
@@ -709,7 +729,27 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
         for mask in ModifierKeyState.modifierMasks where modifier.contains(mask) {
             let key = mask.rawValue
-            modifierCounts[key] = (modifierCounts[key] ?? 0) + 1
+			let count = modifierCounts[key] ?? 0
+			modifierCounts[key] = count + 1
+			if count == 0, let vKey = ModifierKeyState.maskToKeyCode[key] {
+				modifierHeldKeyCodes[key] = CGKeyCode(vKey)
+			}
+			heldModifiers.insert(mask)
+		}
+    }
+
+    private func recordHeldModifierKey(_ keyCode: CGKeyCode) {
+		let modifier = KeyCodeMapping.modifierFlag(for: keyCode)
+		stateLock.lock()
+		defer { stateLock.unlock() }
+
+		for mask in ModifierKeyState.modifierMasks where modifier.contains(mask) {
+			let key = mask.rawValue
+			let count = modifierCounts[key] ?? 0
+			modifierCounts[key] = count + 1
+			if count == 0 {
+				modifierHeldKeyCodes[key] = keyCode
+			}
             heldModifiers.insert(mask)
         }
     }
@@ -723,6 +763,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
             let count = modifierCounts[key] ?? 0
             if count <= 1 {
                 modifierCounts[key] = 0
+				modifierHeldKeyCodes[key] = nil
                 heldModifiers.remove(mask)
             } else {
                 modifierCounts[key] = count - 1
@@ -735,6 +776,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         for key in modifierCounts.keys {
             modifierCounts[key] = 0
         }
+		modifierHeldKeyCodes.removeAll()
         heldModifiers = []
         stateLock.unlock()
     }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -800,6 +800,40 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         sendLine("kp \(keyCode) \(modifiers.rawValue)")
     }
 
+    func sendKeyPress(_ keyCode: CGKeyCode, modifiers: ModifierFlags) -> Bool {
+		let hasExplicitSide = modifiers.commandSide != nil ||
+			modifiers.optionSide != nil ||
+			modifiers.shiftSide != nil ||
+			modifiers.controlSide != nil
+		guard hasExplicitSide else {
+			return sendKeyPress(keyCode, modifiers: modifiers.cgEventFlags)
+		}
+
+		return sendLine(
+			"kp2 \(keyCode) \(modifiers.cgEventFlags.rawValue) " +
+			"\(Self.wireValue(for: modifiers.commandSide)) " +
+			"\(Self.wireValue(for: modifiers.optionSide)) " +
+			"\(Self.wireValue(for: modifiers.shiftSide)) " +
+			"\(Self.wireValue(for: modifiers.controlSide))"
+		)
+    }
+
+    private static func wireValue(for side: ModifierSide?) -> Int {
+		switch side {
+		case .left: return 1
+		case .right: return 2
+		case .none: return 0
+		}
+    }
+
+    private static func modifierSide(from wireValue: Substring) -> ModifierSide? {
+		switch Int(wireValue) {
+		case 1: return .left
+		case 2: return .right
+		default: return nil
+		}
+    }
+
     func sendControllerButtonPressed(_ button: ControllerButton) -> Bool {
         guard hasActiveRemoteSession else { return false }
         return sendLine("bp \(button.rawValue)")
@@ -1993,6 +2027,28 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
                 input?.pressKey(CGKeyCode(keyCode), modifiers: CGEventFlags(rawValue: flagsRaw))
             }
             logFirstReceive("key press \(keyCode)")
+		case "kp2":
+			guard parts.count == 7,
+				  let keyCode = UInt16(parts[1]),
+				  let flagsRaw = UInt64(parts[2]) else { return }
+			let flags = CGEventFlags(rawValue: flagsRaw)
+			let modifiers = ModifierFlags(
+				command: flags.contains(.maskCommand),
+				option: flags.contains(.maskAlternate),
+				shift: flags.contains(.maskShift),
+				control: flags.contains(.maskControl),
+				commandSide: Self.modifierSide(from: parts[3]),
+				optionSide: Self.modifierSide(from: parts[4]),
+				shiftSide: Self.modifierSide(from: parts[5]),
+				controlSide: Self.modifierSide(from: parts[6])
+			)
+			if handlesIncomingRemoteInput && KeyCodeMapping.isMouseButton(CGKeyCode(keyCode)) {
+				postRemoteMouseButton(keyCode: CGKeyCode(keyCode), down: true)
+				postRemoteMouseButton(keyCode: CGKeyCode(keyCode), down: false)
+			} else {
+				input?.pressKey(CGKeyCode(keyCode), modifiers: modifiers)
+			}
+			logFirstReceive("side-aware key press \(keyCode)")
         case "kd":
             guard parts.count == 3,
                   let keyCode = UInt16(parts[1]),
@@ -2000,8 +2056,13 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
 			if handlesIncomingRemoteInput && KeyCodeMapping.isMouseButton(CGKeyCode(keyCode)) {
                 postRemoteMouseButton(keyCode: CGKeyCode(keyCode), down: true)
             } else {
-                updateRemoteMouseButtonState(keyCode: CGKeyCode(keyCode), isDown: true)
-                input?.keyDown(CGKeyCode(keyCode), modifiers: CGEventFlags(rawValue: flagsRaw))
+				let cgKeyCode = CGKeyCode(keyCode)
+				updateRemoteMouseButtonState(keyCode: cgKeyCode, isDown: true)
+				if KeyCodeMapping.isModifierKey(cgKeyCode) {
+					input?.holdModifierKey(cgKeyCode)
+				} else {
+					input?.keyDown(cgKeyCode, modifiers: CGEventFlags(rawValue: flagsRaw))
+				}
             }
             logFirstReceive("key down \(keyCode)")
         case "ku":
@@ -2010,8 +2071,13 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
 			if handlesIncomingRemoteInput && KeyCodeMapping.isMouseButton(CGKeyCode(keyCode)) {
                 postRemoteMouseButton(keyCode: CGKeyCode(keyCode), down: false)
             } else {
-                updateRemoteMouseButtonState(keyCode: CGKeyCode(keyCode), isDown: false)
-                input?.keyUp(CGKeyCode(keyCode))
+				let cgKeyCode = CGKeyCode(keyCode)
+				updateRemoteMouseButtonState(keyCode: cgKeyCode, isDown: false)
+				if KeyCodeMapping.isModifierKey(cgKeyCode) {
+					input?.releaseModifierKey(cgKeyCode)
+				} else {
+					input?.keyUp(cgKeyCode)
+				}
             }
             logFirstReceive("key up \(keyCode)")
         case "hm":

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -290,6 +290,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
     private var client: NWConnection?
     private var clientHost: String?
     private var clientReceiveBuffer = ""
+    private var peerSupportsKP2 = false
     private var authenticator: UniversalControlRelayAuthenticator?
     private var pendingRelayPings: [String: (Bool, String) -> Void] = [:]
     private var pendingOutgoingCodePairing: OutgoingCodePairing?
@@ -723,6 +724,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         activeIncomingPairingPrompt = nil
         pairedRemoteEndpoint = nil
         pairedRemoteEndpointKey = nil
+		peerSupportsKP2 = false
 		remoteHandoffSuppressedUntil = .distantPast
         lock.unlock()
         resetAuthenticator(secretData: relaySharedSecretData())
@@ -797,33 +799,21 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
     }
 
     func sendKeyPress(_ keyCode: CGKeyCode, modifiers: CGEventFlags) -> Bool {
-        sendLine("kp \(keyCode) \(modifiers.rawValue)")
+		sendLine(UniversalControlRelayKeyPressEncoding.line(keyCode: keyCode, modifiers: modifiers))
     }
 
     func sendKeyPress(_ keyCode: CGKeyCode, modifiers: ModifierFlags) -> Bool {
-		let hasExplicitSide = modifiers.commandSide != nil ||
-			modifiers.optionSide != nil ||
-			modifiers.shiftSide != nil ||
-			modifiers.controlSide != nil
-		guard hasExplicitSide else {
-			return sendKeyPress(keyCode, modifiers: modifiers.cgEventFlags)
-		}
+		lock.lock()
+		let supportsKP2 = peerSupportsKP2
+		lock.unlock()
 
 		return sendLine(
-			"kp2 \(keyCode) \(modifiers.cgEventFlags.rawValue) " +
-			"\(Self.wireValue(for: modifiers.commandSide)) " +
-			"\(Self.wireValue(for: modifiers.optionSide)) " +
-			"\(Self.wireValue(for: modifiers.shiftSide)) " +
-			"\(Self.wireValue(for: modifiers.controlSide))"
+			UniversalControlRelayKeyPressEncoding.line(
+				keyCode: keyCode,
+				modifiers: modifiers,
+				peerSupportsKP2: supportsKP2
+			)
 		)
-    }
-
-    private static func wireValue(for side: ModifierSide?) -> Int {
-		switch side {
-		case .left: return 1
-		case .right: return 2
-		case .none: return 0
-		}
     }
 
     private static func modifierSide(from wireValue: Substring) -> ModifierSide? {
@@ -1200,6 +1190,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         lock.lock()
         client = connection
         clientHost = clientKey
+		peerSupportsKP2 = false
         didLogSendFailure = false
         didLogFirstSend = false
         lock.unlock()
@@ -1783,7 +1774,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
                 return
             }
             if let data, !data.isEmpty, let text = String(data: data, encoding: .utf8) {
-                appendClientIncoming(text)
+				appendClientIncoming(text, from: connection)
             }
             if !isComplete {
                 receiveNextFromClient(on: connection)
@@ -1791,7 +1782,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         }
     }
 
-    private func appendClientIncoming(_ text: String) {
+    private func appendClientIncoming(_ text: String, from connection: NWConnection) {
         var lines: [String] = []
         lock.lock()
         clientReceiveBuffer += text
@@ -1808,7 +1799,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         lock.unlock()
 
         for line in lines {
-            handleClient(line: line)
+			handleClient(line: line, from: connection)
         }
     }
 
@@ -1844,6 +1835,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         connection.stateUpdateHandler = { [weak self, weak connection] state in
             guard let connection else { return }
             if case .ready = state {
+				self?.sendConnectionCapabilities(on: connection)
                 self?.receiveNext(on: connection)
             } else if case .failed(let error) = state {
                 NSLog("[UCMouseRelay] Receive connection failed: %@", String(describing: error))
@@ -1951,6 +1943,10 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
             NSLog("[UCMouseRelay] Replied to pairing ping")
             return
         }
+
+		if command == "caps" {
+			return
+		}
 
         lock.lock()
         let input = receiverInput
@@ -2429,13 +2425,18 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
 		}
     }
 
-    private func handleClient(line: String) {
+    private func handleClient(line: String, from connection: NWConnection) {
         guard let payload = openIncomingLine(line) else {
             NSLog("[UCMouseRelay] Rejected unauthenticated client response")
             return
         }
         let parts = payload.split(separator: " ")
         guard let command = parts.first else { return }
+
+		if command == "caps" {
+			recordPeerCapabilities(from: parts, on: connection)
+			return
+		}
 
         if command == "pong" {
             guard parts.count == 2 else { return }
@@ -2507,6 +2508,21 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
             showConfirmedHandoffPortal(for: pendingPortal)
         }
     }
+
+	private func sendConnectionCapabilities(on connection: NWConnection) {
+		_ = sendAuthenticatedLine(UniversalControlRelayKeyPressEncoding.capabilityLine, on: connection)
+	}
+
+	private func recordPeerCapabilities(from parts: [Substring], on connection: NWConnection) {
+		guard UniversalControlRelayKeyPressEncoding.supportsSideAwareKeyPress(parts) else {
+			return
+		}
+		lock.lock()
+		if client === connection {
+			peerSupportsKP2 = true
+		}
+		lock.unlock()
+	}
 
     private func sendRemoteCursorStatus(on connection: NWConnection) {
 		let point = UniversalControlRemoteMouseMovementPolicy.statusPoint(
@@ -3040,6 +3056,51 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
             NSLog("[UCMouseRelay] Sent first move dx=%d dy=%d", dx, dy)
         }
     }
+}
+
+struct UniversalControlRelayKeyPressEncoding {
+	static let sideAwareCapability = "kp2"
+	static let capabilityLine = "caps \(sideAwareCapability)"
+
+	static func line(keyCode: CGKeyCode, modifiers: CGEventFlags) -> String {
+		"kp \(keyCode) \(modifiers.rawValue)"
+	}
+
+	static func line(
+		keyCode: CGKeyCode,
+		modifiers: ModifierFlags,
+		peerSupportsKP2: Bool
+	) -> String {
+		guard peerSupportsKP2, hasExplicitSide(modifiers) else {
+			return line(keyCode: keyCode, modifiers: modifiers.cgEventFlags)
+		}
+
+		return "kp2 \(keyCode) \(modifiers.cgEventFlags.rawValue) " +
+			"\(wireValue(for: modifiers.commandSide)) " +
+			"\(wireValue(for: modifiers.optionSide)) " +
+			"\(wireValue(for: modifiers.shiftSide)) " +
+			"\(wireValue(for: modifiers.controlSide))"
+	}
+
+	static func supportsSideAwareKeyPress(_ parts: [Substring]) -> Bool {
+		guard parts.first == "caps" else { return false }
+		return parts.dropFirst().contains { $0 == sideAwareCapability }
+	}
+
+	private static func hasExplicitSide(_ modifiers: ModifierFlags) -> Bool {
+		modifiers.commandSide != nil ||
+			modifiers.optionSide != nil ||
+			modifiers.shiftSide != nil ||
+			modifiers.controlSide != nil
+	}
+
+	private static func wireValue(for side: ModifierSide?) -> Int {
+		switch side {
+		case .left: return 1
+		case .right: return 2
+		case .none: return 0
+		}
+	}
 }
 
 struct UniversalControlHandoffEdgeDefaults {

--- a/XboxControllerMapper/XboxControllerMapper/Services/Macros/MacroExecutor.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Macros/MacroExecutor.swift
@@ -76,12 +76,11 @@ class MacroExecutor: @unchecked Sendable {
 
     private func pressKeyMapping(_ mapping: KeyMapping) {
         if let keyCode = mapping.keyCode {
-            inputSimulator.pressKey(keyCode, modifiers: mapping.modifiers.cgEventFlags)
+			inputSimulator.pressKey(keyCode, modifiers: mapping.modifiers)
         } else if mapping.modifiers.hasAny {
-            let flags = mapping.modifiers.cgEventFlags
-            inputSimulator.holdModifier(flags)
+			inputSimulator.holdModifiers(mapping.modifiers)
             usleep(Config.keyPressDuration)
-            inputSimulator.releaseModifier(flags)
+			inputSimulator.releaseModifiers(mapping.modifiers)
         }
     }
 
@@ -90,14 +89,27 @@ class MacroExecutor: @unchecked Sendable {
         // community profile can't crash the unsigned conversion to useconds_t.
         let clampedUs = max(0, min(duration * 1_000_000, Double(UInt32.max)))
         if let keyCode = mapping.keyCode {
-            inputSimulator.keyDown(keyCode, modifiers: mapping.modifiers.cgEventFlags)
+			if mapping.modifiers.hasAny {
+				inputSimulator.holdModifiers(mapping.modifiers)
+			}
+			if KeyCodeMapping.isModifierKey(keyCode) {
+				inputSimulator.holdModifierKey(keyCode)
+			} else {
+				inputSimulator.keyDown(keyCode, modifiers: mapping.modifiers.cgEventFlags)
+			}
             usleep(useconds_t(clampedUs))
-            inputSimulator.keyUp(keyCode)
+			if KeyCodeMapping.isModifierKey(keyCode) {
+				inputSimulator.releaseModifierKey(keyCode)
+			} else {
+				inputSimulator.keyUp(keyCode)
+			}
+			if mapping.modifiers.hasAny {
+				inputSimulator.releaseModifiers(mapping.modifiers)
+			}
         } else if mapping.modifiers.hasAny {
-            let flags = mapping.modifiers.cgEventFlags
-            inputSimulator.holdModifier(flags)
+			inputSimulator.holdModifiers(mapping.modifiers)
             usleep(useconds_t(clampedUs))
-            inputSimulator.releaseModifier(flags)
+			inputSimulator.releaseModifiers(mapping.modifiers)
         }
     }
 

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/ActionCommand.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/ActionCommand.swift
@@ -101,15 +101,15 @@ struct KeyPressActionCommand: ActionCommand {
 
 /// Taps a modifier key (hold + delayed release)
 struct ModifierTapActionCommand: ActionCommand {
-    let modifierFlags: CGEventFlags
+    let modifiers: ModifierFlags
     let inputSimulator: InputSimulatorProtocol
     let inputQueue: DispatchQueue
     let action: any ExecutableAction
 
     func execute() -> String {
-        inputSimulator.holdModifier(modifierFlags)
+		inputSimulator.holdModifiers(modifiers)
         inputQueue.asyncAfter(deadline: .now() + Config.modifierReleaseCheckDelay) { [inputSimulator] in
-            inputSimulator.releaseModifier(modifierFlags)
+			inputSimulator.releaseModifiers(modifiers)
         }
         return action.feedbackString
     }
@@ -186,7 +186,7 @@ struct ActionCommandFactory {
 
         if action.modifiers.hasAny {
             return ModifierTapActionCommand(
-                modifierFlags: action.modifiers.cgEventFlags,
+				modifiers: action.modifiers,
                 inputSimulator: inputSimulator,
                 inputQueue: inputQueue,
                 action: action

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/ActionCommand.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/ActionCommand.swift
@@ -83,7 +83,7 @@ struct ScriptActionCommand: ActionCommand {
 /// Executes a key press with optional modifiers
 struct KeyPressActionCommand: ActionCommand {
     let keyCode: CGKeyCode
-    let modifiers: CGEventFlags
+    let modifiers: ModifierFlags
     let inputSimulator: InputSimulatorProtocol
     let action: any ExecutableAction
 
@@ -92,7 +92,7 @@ struct KeyPressActionCommand: ActionCommand {
         if !UniversalControlMouseRelay.shared.isRoutingToRemote {
             // Notify on-screen keyboard of controller key press
             OnScreenKeyboardManager.shared.notifyControllerKeyPress(
-                keyCode: keyCode, modifiers: modifiers
+                keyCode: keyCode, modifiers: modifiers.cgEventFlags
             )
         }
         return action.feedbackString
@@ -178,7 +178,7 @@ struct ActionCommandFactory {
         if let keyCode = action.keyCode {
             return KeyPressActionCommand(
                 keyCode: keyCode,
-                modifiers: action.modifiers.cgEventFlags,
+                modifiers: action.modifiers,
                 inputSimulator: inputSimulator,
                 action: action
             )

--- a/XboxControllerMapper/XboxControllerMapper/Utilities/KeyCodeMapping.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Utilities/KeyCodeMapping.swift
@@ -35,12 +35,19 @@ enum KeyCodeMapping {
     static let f11: CGKeyCode = CGKeyCode(kVK_F11)
     static let f12: CGKeyCode = CGKeyCode(kVK_F12)
 
-    // MARK: - Modifier Keys
+    // MARK: - Modifier Keys (Left)
 
     static let command: CGKeyCode = CGKeyCode(kVK_Command)
     static let shift: CGKeyCode = CGKeyCode(kVK_Shift)
     static let option: CGKeyCode = CGKeyCode(kVK_Option)
     static let control: CGKeyCode = CGKeyCode(kVK_Control)
+
+    // MARK: - Modifier Keys (Right)
+
+    static let rightCommand: CGKeyCode = CGKeyCode(kVK_RightCommand)
+    static let rightShift: CGKeyCode = CGKeyCode(kVK_RightShift)
+    static let rightOption: CGKeyCode = CGKeyCode(kVK_RightOption)
+    static let rightControl: CGKeyCode = CGKeyCode(kVK_RightControl)
 
     // MARK: - Number Keys
 
@@ -244,11 +251,17 @@ enum KeyCodeMapping {
         case kVK_ANSI_Equal: return "="
         case kVK_ANSI_Grave: return "`"
 
-        // Modifiers
-        case kVK_Command: return "Command"
-        case kVK_Shift: return "Shift"
-        case kVK_Option: return "Option"
-        case kVK_Control: return "Control"
+        // Modifiers (Left)
+        case kVK_Command: return "Left ⌘"
+        case kVK_Shift: return "Left ⇧"
+        case kVK_Option: return "Left ⌥"
+        case kVK_Control: return "Left ⌃"
+
+        // Modifiers (Right)
+        case kVK_RightCommand: return "Right ⌘"
+        case kVK_RightShift: return "Right ⇧"
+        case kVK_RightOption: return "Right ⌥"
+        case kVK_RightControl: return "Right ⌃"
         case kVK_CapsLock: return "Caps Lock"
         case kVK_Function: return "Fn"
 
@@ -356,6 +369,16 @@ enum KeyCodeMapping {
         options.append(("=", equal))
         options.append(("`", grave))
 
+        // Modifier keys (Left / Right distinction)
+        options.append(("Left ⌘", command))
+        options.append(("Right ⌘", rightCommand))
+        options.append(("Left ⌥", option))
+        options.append(("Right ⌥", rightOption))
+        options.append(("Left ⇧", shift))
+        options.append(("Right ⇧", rightShift))
+        options.append(("Left ⌃", control))
+        options.append(("Right ⌃", rightControl))
+
         // Mouse buttons
         options.append(("Left Click", mouseLeftClick))
         options.append(("Right Click", mouseRightClick))
@@ -413,6 +436,31 @@ enum KeyCodeMapping {
     /// Checks if a key code is a special marker that shouldn't be sent as a key event
     static func isSpecialMarker(_ keyCode: CGKeyCode) -> Bool {
         isMouseButton(keyCode) || isScrollAction(keyCode) || isSpecialAction(keyCode) || isMediaKey(keyCode)
+    }
+
+    /// Checks if a key code represents a modifier key (left or right variant)
+    static func isModifierKey(_ keyCode: CGKeyCode) -> Bool {
+        switch Int(keyCode) {
+        case kVK_Command, kVK_RightCommand,
+             kVK_Shift, kVK_RightShift,
+             kVK_Option, kVK_RightOption,
+             kVK_Control, kVK_RightControl:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Returns the CGEventFlags mask for a modifier key code, or empty if not a modifier.
+    /// Left and right variants share the same mask (e.g. both Commands → .maskCommand).
+    static func modifierFlag(for keyCode: CGKeyCode) -> CGEventFlags {
+        switch Int(keyCode) {
+        case kVK_Command, kVK_RightCommand: return .maskCommand
+        case kVK_Shift, kVK_RightShift: return .maskShift
+        case kVK_Option, kVK_RightOption: return .maskAlternate
+        case kVK_Control, kVK_RightControl: return .maskControl
+        default: return []
+        }
     }
 
     // MARK: - Character to Key Code Mapping

--- a/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyCaptureField.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyCaptureField.swift
@@ -61,10 +61,10 @@ struct KeyCaptureField: View {
     private func updateDisplayText() {
         var parts: [String] = []
 
-        if modifiers.command { parts.append("⌘") }
-        if modifiers.option { parts.append("⌥") }
-        if modifiers.shift { parts.append("⇧") }
-        if modifiers.control { parts.append("⌃") }
+        if modifiers.command { parts.append(ModifierFlags.label(for: modifiers.commandSide) + "⌘") }
+        if modifiers.option { parts.append(ModifierFlags.label(for: modifiers.optionSide) + "⌥") }
+        if modifiers.shift { parts.append(ModifierFlags.label(for: modifiers.shiftSide) + "⇧") }
+        if modifiers.control { parts.append(ModifierFlags.label(for: modifiers.controlSide) + "⌃") }
 
         if let keyCode = keyCode {
             parts.append(KeyCodeMapping.displayName(for: keyCode))

--- a/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyCaptureField.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyCaptureField.swift
@@ -120,6 +120,9 @@ class KeyCaptureNSView: NSView {
     private var currentModifiers = ModifierFlags()
     private var peakModifiers = ModifierFlags()  // Tracks the maximum set of modifiers held
     private var hasNonModifierKey = false
+    /// Specific modifier key codes (kVK_Command vs kVK_RightCommand, etc.) seen during this capture.
+    /// Lets us preserve left/right identity when the user records just one modifier key on its own.
+    private var capturedModifierKeyCodes: [UInt16] = []
 
     override var acceptsFirstResponder: Bool { true }
 
@@ -130,6 +133,7 @@ class KeyCaptureNSView: NSView {
         currentModifiers = ModifierFlags()
         peakModifiers = ModifierFlags()
         hasNonModifierKey = false
+        capturedModifierKeyCodes = []
 
         let eventMask: NSEvent.EventTypeMask = [
             .keyDown, .flagsChanged,
@@ -177,12 +181,20 @@ class KeyCaptureNSView: NSView {
             ]
 
             if event.type == .flagsChanged {
+                let specificKeyCode = event.keyCode
+
                 // Track current modifier state
                 var mods = ModifierFlags()
                 if event.modifierFlags.contains(.command) { mods.command = true }
                 if event.modifierFlags.contains(.option) { mods.option = true }
                 if event.modifierFlags.contains(.shift) { mods.shift = true }
                 if event.modifierFlags.contains(.control) { mods.control = true }
+
+                // Remember which specific modifier key codes were touched (left vs right).
+                if modifierOnlyKeys.contains(Int(specificKeyCode)) &&
+                   !self.capturedModifierKeyCodes.contains(specificKeyCode) {
+                    self.capturedModifierKeyCodes.append(specificKeyCode)
+                }
 
                 self.currentModifiers = mods
 
@@ -196,7 +208,15 @@ class KeyCaptureNSView: NSView {
                 // If all modifiers are now released and no regular key was pressed,
                 // capture the peak modifiers as a modifier-only shortcut
                 if !mods.hasAny && self.peakModifiers.hasAny && !self.hasNonModifierKey {
-                    self.onKeyCapture?(nil, self.peakModifiers)
+                    // If the user pressed exactly one modifier key on its own, preserve
+                    // the specific left/right key code (e.g. kVK_RightCommand). Otherwise
+                    // fall back to the mask-based modifier-only shortcut.
+                    let sideAwareCodes = self.capturedModifierKeyCodes.filter { Int($0) != kVK_Function }
+                    if sideAwareCodes.count == 1, let code = sideAwareCodes.first {
+                        self.onKeyCapture?(CGKeyCode(code), ModifierFlags())
+                    } else {
+                        self.onKeyCapture?(nil, self.peakModifiers)
+                    }
                     self.stopCapturing()
                 }
 
@@ -230,6 +250,7 @@ class KeyCaptureNSView: NSView {
         currentModifiers = ModifierFlags()
         peakModifiers = ModifierFlags()
         hasNonModifierKey = false
+        capturedModifierKeyCodes = []
     }
 
     deinit {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyCaptureField.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyCaptureField.swift
@@ -147,7 +147,7 @@ class KeyCaptureNSView: NSView {
             // (activation click happens via onTapGesture before monitor starts)
             if event.type == .leftMouseDown || event.type == .rightMouseDown || event.type == .otherMouseDown {
                 // Check if click is within our bounds; if outside, stop capturing and pass through
-                if let window = self.window {
+				if self.window != nil {
                     let locationInView = self.convert(event.locationInWindow, from: nil)
                     if !self.bounds.contains(locationInView) {
                         self.stopCapturing()
@@ -183,27 +183,38 @@ class KeyCaptureNSView: NSView {
             if event.type == .flagsChanged {
                 let specificKeyCode = event.keyCode
 
-                // Track current modifier state
-                var mods = ModifierFlags()
-                if event.modifierFlags.contains(.command) { mods.command = true }
-                if event.modifierFlags.contains(.option) { mods.option = true }
-                if event.modifierFlags.contains(.shift) { mods.shift = true }
-                if event.modifierFlags.contains(.control) { mods.control = true }
-
                 // Remember which specific modifier key codes were touched (left vs right).
                 if modifierOnlyKeys.contains(Int(specificKeyCode)) &&
                    !self.capturedModifierKeyCodes.contains(specificKeyCode) {
                     self.capturedModifierKeyCodes.append(specificKeyCode)
                 }
 
+				// Track current modifier state, preserving side when exactly one side of
+				// a modifier has been involved in this capture.
+				let mods = Self.modifierFlags(
+					from: event.modifierFlags,
+					capturedKeyCodes: self.capturedModifierKeyCodes
+				)
                 self.currentModifiers = mods
 
                 // Track the peak (maximum) modifiers held during this capture session
                 // This ensures Command+Shift captures both even if released one at a time
-                if mods.command { self.peakModifiers.command = true }
-                if mods.option { self.peakModifiers.option = true }
-                if mods.shift { self.peakModifiers.shift = true }
-                if mods.control { self.peakModifiers.control = true }
+				if mods.command {
+					self.peakModifiers.command = true
+					self.peakModifiers.commandSide = mods.commandSide
+				}
+				if mods.option {
+					self.peakModifiers.option = true
+					self.peakModifiers.optionSide = mods.optionSide
+				}
+				if mods.shift {
+					self.peakModifiers.shift = true
+					self.peakModifiers.shiftSide = mods.shiftSide
+				}
+				if mods.control {
+					self.peakModifiers.control = true
+					self.peakModifiers.controlSide = mods.controlSide
+				}
 
                 // If all modifiers are now released and no regular key was pressed,
                 // capture the peak modifiers as a modifier-only shortcut
@@ -240,6 +251,64 @@ class KeyCaptureNSView: NSView {
 
             return event
         }
+    }
+
+	static func modifierFlags(
+		from eventFlags: NSEvent.ModifierFlags,
+		capturedKeyCodes: [UInt16]
+    ) -> ModifierFlags {
+		var modifiers = ModifierFlags(
+			command: eventFlags.contains(.command),
+			option: eventFlags.contains(.option),
+			shift: eventFlags.contains(.shift),
+			control: eventFlags.contains(.control)
+		)
+
+		if modifiers.command {
+			modifiers.commandSide = capturedSide(
+				leftKey: kVK_Command,
+				rightKey: kVK_RightCommand,
+				capturedKeyCodes: capturedKeyCodes
+			)
+		}
+		if modifiers.option {
+			modifiers.optionSide = capturedSide(
+				leftKey: kVK_Option,
+				rightKey: kVK_RightOption,
+				capturedKeyCodes: capturedKeyCodes
+			)
+		}
+		if modifiers.shift {
+			modifiers.shiftSide = capturedSide(
+				leftKey: kVK_Shift,
+				rightKey: kVK_RightShift,
+				capturedKeyCodes: capturedKeyCodes
+			)
+		}
+		if modifiers.control {
+			modifiers.controlSide = capturedSide(
+				leftKey: kVK_Control,
+				rightKey: kVK_RightControl,
+				capturedKeyCodes: capturedKeyCodes
+			)
+		}
+
+		return modifiers
+    }
+
+	private static func capturedSide(
+		leftKey: Int,
+		rightKey: Int,
+		capturedKeyCodes: [UInt16]
+    ) -> ModifierSide? {
+		let hasLeft = capturedKeyCodes.contains(UInt16(leftKey))
+		let hasRight = capturedKeyCodes.contains(UInt16(rightKey))
+
+		switch (hasLeft, hasRight) {
+		case (true, false): return .left
+		case (false, true): return .right
+		default: return nil
+		}
     }
 
     func stopCapturing() {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyboardVisualView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyboardVisualView.swift
@@ -43,10 +43,10 @@ struct KeyboardVisualView: View {
 
     private var modifierRow: some View {
         HStack(spacing: 16) {
-            ModifierToggle(label: "⌘ Command", isOn: $modifiers.command)
-            ModifierToggle(label: "⌥ Option", isOn: $modifiers.option)
-            ModifierToggle(label: "⇧ Shift", isOn: $modifiers.shift)
-            ModifierToggle(label: "⌃ Control", isOn: $modifiers.control)
+            ModifierToggle(label: "⌘ Command", isOn: $modifiers.command, side: $modifiers.commandSide)
+            ModifierToggle(label: "⌥ Option", isOn: $modifiers.option, side: $modifiers.optionSide)
+            ModifierToggle(label: "⇧ Shift", isOn: $modifiers.shift, side: $modifiers.shiftSide)
+            ModifierToggle(label: "⌃ Control", isOn: $modifiers.control, side: $modifiers.controlSide)
 
             Spacer()
 
@@ -161,7 +161,7 @@ struct KeyboardVisualView: View {
 
     private var zxcvRow: some View {
         HStack(spacing: 4) {
-            ModifierKeyButton(label: "⇧ Shift", width: 80, isActive: $modifiers.shift)
+            ModifierKeyButton(label: "⇧ Shift", width: 80, isActive: $modifiers.shift, physicalSide: .left, activeSide: modifiers.shiftSide)
 
             let zxcvKeys = ["Z", "X", "C", "V", "B", "N", "M"]
             let zxcvCodes: [Int] = [kVK_ANSI_Z, kVK_ANSI_X, kVK_ANSI_C, kVK_ANSI_V, kVK_ANSI_B, kVK_ANSI_N, kVK_ANSI_M]
@@ -173,7 +173,7 @@ struct KeyboardVisualView: View {
             KeyButton(keyCode: CGKeyCode(kVK_ANSI_Comma), label: ",", selectedKeyCode: $selectedKeyCode, hoveredKey: $hoveredKey)
             KeyButton(keyCode: CGKeyCode(kVK_ANSI_Period), label: ".", selectedKeyCode: $selectedKeyCode, hoveredKey: $hoveredKey)
             KeyButton(keyCode: CGKeyCode(kVK_ANSI_Slash), label: "/", selectedKeyCode: $selectedKeyCode, hoveredKey: $hoveredKey)
-            ModifierKeyButton(label: "⇧ Shift", width: 80, isActive: $modifiers.shift)
+            ModifierKeyButton(label: "⇧ Shift", width: 80, isActive: $modifiers.shift, physicalSide: .right, activeSide: modifiers.shiftSide)
         }
     }
 
@@ -191,14 +191,14 @@ struct KeyboardVisualView: View {
                     RoundedRectangle(cornerRadius: 4)
                         .stroke(Color.gray.opacity(0.3), lineWidth: 1)
                 )
-            ModifierKeyButton(label: "⌃", width: 40, isActive: $modifiers.control)
-            ModifierKeyButton(label: "⌥", width: 40, isActive: $modifiers.option)
-            ModifierKeyButton(label: "⌘", width: 50, isActive: $modifiers.command)
+            ModifierKeyButton(label: "⌃", width: 40, isActive: $modifiers.control, physicalSide: .left, activeSide: modifiers.controlSide)
+            ModifierKeyButton(label: "⌥", width: 40, isActive: $modifiers.option, physicalSide: .left, activeSide: modifiers.optionSide)
+            ModifierKeyButton(label: "⌘", width: 50, isActive: $modifiers.command, physicalSide: .left, activeSide: modifiers.commandSide)
 
             KeyButton(keyCode: CGKeyCode(kVK_Space), label: "Space", width: 200, selectedKeyCode: $selectedKeyCode, hoveredKey: $hoveredKey)
 
-            ModifierKeyButton(label: "⌘", width: 50, isActive: $modifiers.command)
-            ModifierKeyButton(label: "⌥", width: 40, isActive: $modifiers.option)
+            ModifierKeyButton(label: "⌘", width: 50, isActive: $modifiers.command, physicalSide: .right, activeSide: modifiers.commandSide)
+            ModifierKeyButton(label: "⌥", width: 40, isActive: $modifiers.option, physicalSide: .right, activeSide: modifiers.optionSide)
 
             // Arrow keys cluster
             VStack(spacing: 2) {
@@ -327,13 +327,26 @@ struct KeyboardVisualView: View {
 
 // MARK: - Modifier Key Button (toggleable)
 
+/// A modifier key on the keyboard layout. Clicking toggles the modifier mask flag.
+/// Highlighting reflects the selected side: when `activeSide` is nil ("Any"), both
+/// physical positions highlight; when `.left` or `.right` is selected, only the
+/// matching physical position highlights.
 struct ModifierKeyButton: View {
     let label: String
     var width: CGFloat = 40
     var height: CGFloat = 32
     @Binding var isActive: Bool
+    /// Which physical side of the keyboard this button represents
+    let physicalSide: ModifierSide
+    /// Currently selected side for this modifier (nil = Any → highlight both sides)
+    let activeSide: ModifierSide?
 
     @State private var isHovered = false
+
+    /// Whether THIS button should appear highlighted given the side selection.
+    private var isHighlighted: Bool {
+        isActive && (activeSide == nil || activeSide == physicalSide)
+    }
 
     var body: some View {
         Button(action: { isActive.toggle() }) {
@@ -345,7 +358,7 @@ struct ModifierKeyButton: View {
                 .cornerRadius(4)
                 .overlay(
                     RoundedRectangle(cornerRadius: 4)
-                        .stroke(borderColor, lineWidth: isActive ? 2 : 1)
+                        .stroke(borderColor, lineWidth: isHighlighted ? 2 : 1)
                 )
         }
         .buttonStyle(.plain)
@@ -364,7 +377,7 @@ struct ModifierKeyButton: View {
     }
 
     private var backgroundColor: Color {
-        if isActive {
+        if isHighlighted {
             return .accentColor
         } else if isHovered {
             return Color.accentColor.opacity(0.3)
@@ -374,11 +387,11 @@ struct ModifierKeyButton: View {
     }
 
     private var foregroundColor: Color {
-        isActive ? .white : .primary
+        isHighlighted ? .white : .primary
     }
 
     private var borderColor: Color {
-        if isActive {
+        if isHighlighted {
             return .accentColor
         } else if isHovered {
             return .accentColor.opacity(0.5)
@@ -530,20 +543,61 @@ struct MediaKeyButton: View {
 
 // MARK: - Modifier Toggle
 
+/// Checkbox-style toggle for a modifier flag, with an inline L/R side picker
+/// that appears once the modifier is active. Side defaults to `nil` (either side
+/// — the simulator presses the Left keycode by default).
 struct ModifierToggle: View {
     let label: String
     @Binding var isOn: Bool
+    @Binding var side: ModifierSide?
 
     var body: some View {
-        Button(action: { isOn.toggle() }) {
-            HStack(spacing: 4) {
-                Image(systemName: isOn ? "checkmark.square.fill" : "square")
-                    .foregroundColor(isOn ? .accentColor : .secondary)
-                Text(label)
-                    .font(.caption)
+        HStack(spacing: 8) {
+            Button(action: {
+                isOn.toggle()
+                if !isOn { side = nil }
+            }) {
+                HStack(spacing: 4) {
+                    Image(systemName: isOn ? "checkmark.square.fill" : "square")
+                        .foregroundColor(isOn ? .accentColor : .secondary)
+                    Text(label)
+                        .font(.caption)
+                        .lineLimit(1)
+                }
+            }
+            .buttonStyle(.plain)
+
+            if isOn {
+                HStack(spacing: 2) {
+                    sideChip(label: "Any", value: nil)
+                    sideChip(label: "L", value: .left)
+                    sideChip(label: "R", value: .right)
+                }
+                .transition(.opacity)
             }
         }
+        .fixedSize(horizontal: true, vertical: false)
+    }
+
+    private func sideChip(label: String, value: ModifierSide?) -> some View {
+        let isSelected = side == value
+        return Button(action: { side = value }) {
+            Text(label)
+                .font(.system(size: 9, weight: .semibold))
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(isSelected ? Color.accentColor : Color(nsColor: .controlBackgroundColor))
+                .foregroundColor(isSelected ? .white : .secondary)
+                .cornerRadius(3)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(isSelected ? Color.accentColor : Color.gray.opacity(0.4), lineWidth: 1)
+                )
+        }
         .buttonStyle(.plain)
+        .help("\(label) \(label == "Any" ? "side" : "side only")")
     }
 }
 

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
@@ -383,7 +383,21 @@ struct ButtonMappingSheet: View {
             .onChange(of: primaryState.keyCode) { _, newValue in
                 guard !isLoading else { return }
 
-                if let code = newValue, KeyCodeMapping.isMouseButton(code) || KeyCodeMapping.isSpecialAction(code) {
+                if let code = newValue, KeyCodeMapping.isModifierKey(code) {
+                    // Modifier keys: auto-enable hold (so the modifier stays pressed while
+                    // the controller button is held) and disable long hold / double tap / repeat
+                    // which don't make sense for a sticky modifier.
+                    if !userHasInteractedWithHold {
+                        isHoldModifier = true
+                    }
+                    enableLongHold = false
+                    enableDoubleTap = false
+                    enableRepeat = false
+                    longHoldState.keyCode = nil
+                    longHoldState.modifiers = ModifierFlags()
+                    doubleTapState.keyCode = nil
+                    doubleTapState.modifiers = ModifierFlags()
+                } else if let code = newValue, KeyCodeMapping.isMouseButton(code) || KeyCodeMapping.isSpecialAction(code) {
                     // Mouse clicks and special actions: auto-enable hold and disable long hold/double tap/repeat
                     // Exception: visual tools default to toggle mode (isHoldModifier = false)
                     if !userHasInteractedWithHold {

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/MappingEditorState.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/MappingEditorState.swift
@@ -70,10 +70,10 @@ struct MappingEditorState {
 
     var mappingDisplayString: String {
         var parts: [String] = []
-        if modifiers.command { parts.append("\u{2318}") }
-        if modifiers.option { parts.append("\u{2325}") }
-        if modifiers.shift { parts.append("\u{21E7}") }
-        if modifiers.control { parts.append("\u{2303}") }
+        if modifiers.command { parts.append(ModifierFlags.label(for: modifiers.commandSide) + "\u{2318}") }
+        if modifiers.option { parts.append(ModifierFlags.label(for: modifiers.optionSide) + "\u{2325}") }
+        if modifiers.shift { parts.append(ModifierFlags.label(for: modifiers.shiftSide) + "\u{21E7}") }
+        if modifiers.control { parts.append(ModifierFlags.label(for: modifiers.controlSide) + "\u{2303}") }
         if let keyCode = keyCode {
             parts.append(KeyCodeMapping.displayName(for: keyCode))
         }

--- a/XboxControllerMapper/XboxControllerMapperTests/KeyCodeMappingDisplayTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/KeyCodeMappingDisplayTests.swift
@@ -94,6 +94,58 @@ final class KeyCodeMappingDisplayTests: XCTestCase {
         XCTAssertFalse(KeyCodeMapping.isMouseButton(KeyCodeMapping.scrollDown))
     }
 
+    func testDisplayName_DistinguishesLeftAndRightModifiers() {
+        XCTAssertEqual(KeyCodeMapping.displayName(for: CGKeyCode(kVK_Command)), "Left ⌘")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: CGKeyCode(kVK_RightCommand)), "Right ⌘")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: CGKeyCode(kVK_Option)), "Left ⌥")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: CGKeyCode(kVK_RightOption)), "Right ⌥")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: CGKeyCode(kVK_Shift)), "Left ⇧")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: CGKeyCode(kVK_RightShift)), "Right ⇧")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: CGKeyCode(kVK_Control)), "Left ⌃")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: CGKeyCode(kVK_RightControl)), "Right ⌃")
+    }
+
+    func testIsModifierKey_AcceptsLeftAndRightVariants() {
+        XCTAssertTrue(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_Command)))
+        XCTAssertTrue(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_RightCommand)))
+        XCTAssertTrue(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_Shift)))
+        XCTAssertTrue(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_RightShift)))
+        XCTAssertTrue(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_Option)))
+        XCTAssertTrue(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_RightOption)))
+        XCTAssertTrue(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_Control)))
+        XCTAssertTrue(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_RightControl)))
+
+        XCTAssertFalse(KeyCodeMapping.isModifierKey(KeyCodeMapping.keyA))
+        XCTAssertFalse(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_CapsLock)))
+        XCTAssertFalse(KeyCodeMapping.isModifierKey(CGKeyCode(kVK_Function)))
+        XCTAssertFalse(KeyCodeMapping.isModifierKey(KeyCodeMapping.mouseLeftClick))
+    }
+
+    func testModifierFlag_CollapsesLeftAndRightToSameMask() {
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_Command)), .maskCommand)
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_RightCommand)), .maskCommand)
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_Shift)), .maskShift)
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_RightShift)), .maskShift)
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_Option)), .maskAlternate)
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_RightOption)), .maskAlternate)
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_Control)), .maskControl)
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_RightControl)), .maskControl)
+
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: KeyCodeMapping.keyA), [])
+        XCTAssertEqual(KeyCodeMapping.modifierFlag(for: CGKeyCode(kVK_Function)), [])
+    }
+
+    func testAllKeyOptions_IncludesLeftAndRightModifiers() {
+        let options = KeyCodeMapping.allKeyOptions
+        XCTAssertTrue(options.contains(where: { $0.code == CGKeyCode(kVK_Command) }),
+                      "Picker should expose Left ⌘ as a selectable option")
+        XCTAssertTrue(options.contains(where: { $0.code == CGKeyCode(kVK_RightCommand) }),
+                      "Picker should expose Right ⌘ as a selectable option")
+        XCTAssertTrue(options.contains(where: { $0.code == CGKeyCode(kVK_RightShift) }))
+        XCTAssertTrue(options.contains(where: { $0.code == CGKeyCode(kVK_RightOption) }))
+        XCTAssertTrue(options.contains(where: { $0.code == CGKeyCode(kVK_RightControl) }))
+    }
+
     func testSpecialMarkerClassifiers() {
         XCTAssertTrue(KeyCodeMapping.isMouseButton(KeyCodeMapping.mouseLeftClick))
         XCTAssertTrue(KeyCodeMapping.isMouseButton(KeyCodeMapping.mouseRightClick))

--- a/XboxControllerMapper/XboxControllerMapperTests/ModifierFlagsSideTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ModifierFlagsSideTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import CoreGraphics
 import Carbon.HIToolbox
+import AppKit
 @testable import ControllerKeys
 
 final class ModifierFlagsSideTests: XCTestCase {
@@ -132,6 +133,30 @@ final class ModifierFlagsSideTests: XCTestCase {
 			.holdModifierKey(CGKeyCode(kVK_RightCommand)),
 			.releaseModifierKey(CGKeyCode(kVK_RightCommand))
 		])
+    }
+
+	@MainActor
+	func testKeyCaptureModifierFlags_PreservesSidesForModifierKeyShortcut() {
+		let modifiers = KeyCaptureNSView.modifierFlags(
+			from: [.command, .shift],
+			capturedKeyCodes: [UInt16(kVK_RightCommand), UInt16(kVK_Shift)]
+		)
+
+		XCTAssertTrue(modifiers.command)
+		XCTAssertTrue(modifiers.shift)
+		XCTAssertEqual(modifiers.commandSide, .right)
+		XCTAssertEqual(modifiers.shiftSide, .left)
+    }
+
+	@MainActor
+	func testKeyCaptureModifierFlags_UsesAnyWhenBothSidesWereCaptured() {
+		let modifiers = KeyCaptureNSView.modifierFlags(
+			from: [.command],
+			capturedKeyCodes: [UInt16(kVK_Command), UInt16(kVK_RightCommand)]
+		)
+
+		XCTAssertTrue(modifiers.command)
+		XCTAssertNil(modifiers.commandSide)
     }
 }
 

--- a/XboxControllerMapper/XboxControllerMapperTests/ModifierFlagsSideTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ModifierFlagsSideTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+import CoreGraphics
+import Carbon.HIToolbox
+@testable import ControllerKeys
+
+final class ModifierFlagsSideTests: XCTestCase {
+
+    func testVirtualKey_DefaultsToLeftWhenNoSideSet() {
+        let flags = ModifierFlags(command: true, option: true, shift: true, control: true)
+        XCTAssertEqual(flags.virtualKey(forMask: .maskCommand), CGKeyCode(kVK_Command))
+        XCTAssertEqual(flags.virtualKey(forMask: .maskAlternate), CGKeyCode(kVK_Option))
+        XCTAssertEqual(flags.virtualKey(forMask: .maskShift), CGKeyCode(kVK_Shift))
+        XCTAssertEqual(flags.virtualKey(forMask: .maskControl), CGKeyCode(kVK_Control))
+    }
+
+    func testVirtualKey_HonorsRightSide() {
+        let flags = ModifierFlags(
+            command: true, option: true, shift: true, control: true,
+            commandSide: .right, optionSide: .right, shiftSide: .right, controlSide: .right
+        )
+        XCTAssertEqual(flags.virtualKey(forMask: .maskCommand), CGKeyCode(kVK_RightCommand))
+        XCTAssertEqual(flags.virtualKey(forMask: .maskAlternate), CGKeyCode(kVK_RightOption))
+        XCTAssertEqual(flags.virtualKey(forMask: .maskShift), CGKeyCode(kVK_RightShift))
+        XCTAssertEqual(flags.virtualKey(forMask: .maskControl), CGKeyCode(kVK_RightControl))
+    }
+
+    func testVirtualKey_HonorsExplicitLeftSide() {
+        let flags = ModifierFlags(command: true, commandSide: .left)
+        XCTAssertEqual(flags.virtualKey(forMask: .maskCommand), CGKeyCode(kVK_Command))
+    }
+
+    func testCgEventFlags_IgnoresSide() {
+        // OS-level mask is the same regardless of side
+        let leftFlags = ModifierFlags(command: true, commandSide: .left)
+        let rightFlags = ModifierFlags(command: true, commandSide: .right)
+        let unspecifiedFlags = ModifierFlags(command: true)
+        XCTAssertEqual(leftFlags.cgEventFlags, .maskCommand)
+        XCTAssertEqual(rightFlags.cgEventFlags, .maskCommand)
+        XCTAssertEqual(unspecifiedFlags.cgEventFlags, .maskCommand)
+    }
+
+    func testLabel_FormatsSidePrefix() {
+        XCTAssertEqual(ModifierFlags.label(for: nil), "")
+        XCTAssertEqual(ModifierFlags.label(for: .left), "L")
+        XCTAssertEqual(ModifierFlags.label(for: .right), "R")
+    }
+
+    // MARK: - Codable backward compatibility
+
+    func testDecode_LegacyJsonWithoutSideFields() throws {
+        // JSON shape from before this feature — no *Side keys
+        let legacy = """
+        {"command": true, "option": false, "shift": true, "control": false}
+        """.data(using: .utf8)!
+
+        let flags = try JSONDecoder().decode(ModifierFlags.self, from: legacy)
+        XCTAssertTrue(flags.command)
+        XCTAssertFalse(flags.option)
+        XCTAssertTrue(flags.shift)
+        XCTAssertFalse(flags.control)
+        XCTAssertNil(flags.commandSide)
+        XCTAssertNil(flags.optionSide)
+        XCTAssertNil(flags.shiftSide)
+        XCTAssertNil(flags.controlSide)
+    }
+
+    func testDecode_NewJsonWithSideFields() throws {
+        let json = """
+        {
+            "command": true, "option": false, "shift": true, "control": false,
+            "commandSide": "right", "shiftSide": "left"
+        }
+        """.data(using: .utf8)!
+
+        let flags = try JSONDecoder().decode(ModifierFlags.self, from: json)
+        XCTAssertEqual(flags.commandSide, .right)
+        XCTAssertEqual(flags.shiftSide, .left)
+        XCTAssertNil(flags.optionSide)
+        XCTAssertNil(flags.controlSide)
+    }
+
+    func testRoundTrip_SidesPreserved() throws {
+        let original = ModifierFlags(
+            command: true, option: true, shift: false, control: false,
+            commandSide: .right, optionSide: .left
+        )
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(ModifierFlags.self, from: data)
+        XCTAssertEqual(original, decoded)
+    }
+}

--- a/XboxControllerMapper/XboxControllerMapperTests/ModifierFlagsSideTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ModifierFlagsSideTests.swift
@@ -88,4 +88,129 @@ final class ModifierFlagsSideTests: XCTestCase {
         let decoded = try JSONDecoder().decode(ModifierFlags.self, from: data)
         XCTAssertEqual(original, decoded)
     }
+
+    func testHoldModifiers_UsesSideAwareKeyCodesInPressAndReleaseOrder() {
+		let simulator = RecordingInputSimulator()
+		let flags = ModifierFlags(
+			command: true,
+			option: true,
+			commandSide: .right,
+			optionSide: .left
+		)
+
+		simulator.holdModifiers(flags)
+		simulator.releaseModifiers(flags)
+
+		XCTAssertEqual(simulator.events, [
+			.holdModifierKey(CGKeyCode(kVK_RightCommand)),
+			.holdModifierKey(CGKeyCode(kVK_Option)),
+			.releaseModifierKey(CGKeyCode(kVK_Option)),
+			.releaseModifierKey(CGKeyCode(kVK_RightCommand))
+		])
+    }
+
+    func testModifierTapActionCommand_PreservesRightSide() {
+		let simulator = RecordingInputSimulator()
+		let queue = DispatchQueue(label: "test.modifierTap.side")
+		let action = KeyMapping(modifiers: ModifierFlags(command: true, commandSide: .right))
+		let command = ModifierTapActionCommand(
+			modifiers: action.modifiers,
+			inputSimulator: simulator,
+			inputQueue: queue,
+			action: action
+		)
+
+		_ = command.execute()
+
+		let releaseFinished = expectation(description: "modifier release")
+		queue.asyncAfter(deadline: .now() + Config.modifierReleaseCheckDelay + 0.02) {
+			releaseFinished.fulfill()
+		}
+		wait(for: [releaseFinished], timeout: 1)
+
+		XCTAssertEqual(simulator.events, [
+			.holdModifierKey(CGKeyCode(kVK_RightCommand)),
+			.releaseModifierKey(CGKeyCode(kVK_RightCommand))
+		])
+    }
+}
+
+private final class RecordingInputSimulator: InputSimulatorProtocol, @unchecked Sendable {
+    enum Event: Equatable {
+		case pressKey(CGKeyCode, CGEventFlags)
+		case pressKeyWithModifierFlags(CGKeyCode, ModifierFlags)
+		case keyDown(CGKeyCode, CGEventFlags)
+		case keyUp(CGKeyCode)
+		case holdModifier(CGEventFlags)
+		case releaseModifier(CGEventFlags)
+		case holdModifierKey(CGKeyCode)
+		case releaseModifierKey(CGKeyCode)
+    }
+
+    private let lock = NSLock()
+    private var recordedEvents: [Event] = []
+
+    var events: [Event] {
+		lock.lock()
+		defer { lock.unlock() }
+		return recordedEvents
+    }
+
+    private func record(_ event: Event) {
+		lock.lock()
+		defer { lock.unlock() }
+		recordedEvents.append(event)
+    }
+
+    func pressKey(_ keyCode: CGKeyCode, modifiers: CGEventFlags) {
+		record(.pressKey(keyCode, modifiers))
+    }
+
+    func pressKey(_ keyCode: CGKeyCode, modifiers: ModifierFlags) {
+		record(.pressKeyWithModifierFlags(keyCode, modifiers))
+    }
+
+    func keyDown(_ keyCode: CGKeyCode, modifiers: CGEventFlags) {
+		record(.keyDown(keyCode, modifiers))
+    }
+
+    func keyUp(_ keyCode: CGKeyCode) {
+		record(.keyUp(keyCode))
+    }
+
+    func holdModifier(_ modifier: CGEventFlags) {
+		record(.holdModifier(modifier))
+    }
+
+    func releaseModifier(_ modifier: CGEventFlags) {
+		record(.releaseModifier(modifier))
+    }
+
+    func holdModifierKey(_ keyCode: CGKeyCode) {
+		record(.holdModifierKey(keyCode))
+    }
+
+    func releaseModifierKey(_ keyCode: CGKeyCode) {
+		record(.releaseModifierKey(keyCode))
+    }
+
+    func releaseAllModifiers() {}
+    func isHoldingModifiers(_ modifier: CGEventFlags) -> Bool { false }
+    func getHeldModifiers() -> CGEventFlags { [] }
+    func moveMouse(dx: CGFloat, dy: CGFloat) {}
+    func moveMouseNative(dx: Int, dy: Int) {}
+    func warpMouseTo(point: CGPoint) {}
+    var isLeftMouseButtonHeld: Bool { false }
+    func scroll(
+		dx: CGFloat,
+		dy: CGFloat,
+		phase: CGScrollPhase?,
+		momentumPhase: CGMomentumScrollPhase?,
+		isContinuous: Bool,
+		flags: CGEventFlags
+    ) {}
+    func executeMapping(_ mapping: KeyMapping) {}
+    func startHoldMapping(_ mapping: KeyMapping) {}
+    func stopHoldMapping(_ mapping: KeyMapping) {}
+    func typeText(_ text: String, speed: Int, pressEnter: Bool) {}
 }

--- a/XboxControllerMapper/XboxControllerMapperTests/UniversalControlRelaySecurityTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/UniversalControlRelaySecurityTests.swift
@@ -168,6 +168,45 @@ final class UniversalControlRelaySecurityTests: XCTestCase {
         XCTAssertFalse(UniversalControlMouseRelay.shared.sendSystemCommand(command))
     }
 
+	func testSideAwareKeyPressFallsBackToLegacyEncodingWithoutCapability() {
+		let modifiers = ModifierFlags(command: true, commandSide: .right)
+
+		let line = UniversalControlRelayKeyPressEncoding.line(
+			keyCode: 36,
+			modifiers: modifiers,
+			peerSupportsKP2: false
+		)
+
+		XCTAssertEqual(line, "kp 36 \(modifiers.cgEventFlags.rawValue)")
+	}
+
+	func testSideAwareKeyPressUsesKP2OnlyWithCapability() {
+		let modifiers = ModifierFlags(
+			command: true,
+			option: true,
+			commandSide: .right,
+			optionSide: .left
+		)
+
+		let line = UniversalControlRelayKeyPressEncoding.line(
+			keyCode: 36,
+			modifiers: modifiers,
+			peerSupportsKP2: true
+		)
+
+		XCTAssertEqual(line, "kp2 36 \(modifiers.cgEventFlags.rawValue) 2 1 0 0")
+	}
+
+	func testRelayCapabilityParserRecognizesKP2() {
+		XCTAssertEqual(UniversalControlRelayKeyPressEncoding.capabilityLine, "caps kp2")
+		XCTAssertTrue(
+			UniversalControlRelayKeyPressEncoding.supportsSideAwareKeyPress(["caps", "kp2"])
+		)
+		XCTAssertFalse(
+			UniversalControlRelayKeyPressEncoding.supportsSideAwareKeyPress(["caps", "other"])
+		)
+	}
+
     func testCodePairingDerivesSameSixDigitCodeAndKey() {
         let initiator = UniversalControlRelayPairingSession(localPeerID: "macbook", nonce: "aaa")
         let receiver = UniversalControlRelayPairingSession(localPeerID: "studio", nonce: "bbb")


### PR DESCRIPTION
## Summary
- Adds support for mapping a controller button to a specific physical modifier (Left/Right Command, Option, Shift, Control) instead of treating them as generic modifier flags.
- `KeyCaptureField` preserves left/right identity when the user records a single modifier key on its own.
- `InputSimulator` gains side-aware `holdModifierKey` / `releaseModifierKey` that post the exact virtualKey while still reference-counting by modifier mask, so overlapping mappings stay sane.
- The Universal Control relay path also forwards the specific keycode, so the L/R distinction survives a remote session.

## Credit
Ported from [@lijie2333](https://github.com/lijie2333)'s fork [`xbox-controller-vibe-coding@32268e7`](https://github.com/lijie2333/xbox-controller-vibe-coding/commit/32268e7) and adapted to the current `InputSimulator` / `UniversalControlMouseRelay` / `ButtonMappingSheet` structure. The UC-relay routing for L/R keycodes is a small extension beyond the original fork patch.

## Implementation notes
- `KeyCodeMapping`: adds `kVK_Right*` constants, distinguishes them in `displayName` (`Left ⌘` / `Right ⌘`, etc.), exposes them in `allKeyOptions`, and adds `isModifierKey(_:)` / `modifierFlag(for:)` helpers.
- `InputSimulator.postKeyEvent`: when emitting a modifier key-down, inserts its own flag (`.maskCommand` etc.) so macOS actually registers the modifier state.
- `InputSimulator.executeMapping` / `startHoldMapping` / `stopHoldMapping`: when the keyCode is a modifier, route through `holdModifierKey` + delayed `releaseModifierKey` instead of the regular `pressKey` / `keyDown` / `keyUp` path. This matches the existing modifier-only mapping behavior.
- `ButtonMappingSheet`: selecting a modifier keycode auto-enables hold mode and disables long-hold / double-tap / repeat (which don't make sense for a sticky modifier), mirroring the existing behavior for mouse buttons / special actions.

## Test plan
- [x] `make test-regressions` passes
- [x] New `KeyCodeMappingDisplayTests` cover the new `isModifierKey`, `modifierFlag`, `displayName`, and `allKeyOptions` paths
- [x] `make install BUILD_FROM_SOURCE=1` builds Release cleanly
- [ ] Smoke-test on a real controller: map LB → Right ⌘, hold LB, verify a real Right-Command-only shortcut fires (e.g. a Karabiner rule or app that distinguishes the side)
- [ ] Smoke-test capture flow: in Button Mapping sheet, click "Record", press only Right Command, release — verify the field shows `Right ⌘`
- [ ] Smoke-test that existing single-side mappings (`Left ⌘` recorded from a regular Cmd press) still work the same as before this PR

## Notes
- One pre-existing flake observed: `MappingEngineLayerAndLifecycleTests.testLocalControllerButton_doesNotExecuteHomeMappingDuringRemoteSession` fails on `main` too, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Left/right modifier variants supported across mappings, UI, capture, display and keyboard visuals (Any / L / R).
  * Side-aware remote key relay so peer connections can send/receive left/right modifier info.
  * Auto-enable “Hold action” when assigning a modifier for sticky behavior.

* **Bug Fixes**
  * Improved modifier press/release ordering and tracking to avoid stuck modifiers.
  * More accurate detection/emission of modifier-only shortcuts.

* **Tests**
  * Added tests for modifier-side behavior, display, relay encoding, and JSON compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->