### PR TITLE
🎨 Palette: Add accessibility labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing Accessibility Labels for Icon-Only Buttons
+**Learning:** Found several icon-only buttons (like Edit/Trash) in the UI that lack accessibility labels and tooltips, which are crucial for screen reader users and normal users to understand their function.
+**Action:** Always add `.help("Description")` and `.accessibilityLabel("Description")` to icon-only buttons.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
@@ -106,12 +106,16 @@ struct QuickTextRowView<SuggestionsView: View>: View {
                         Image(systemName: "pencil")
                     }
                     .buttonStyle(.borderless)
+                    .help("Edit")
+                    .accessibilityLabel("Edit")
 
                     Button(action: onDelete) {
                         Image(systemName: "trash")
                             .foregroundColor(.red)
                     }
                     .buttonStyle(.borderless)
+                    .help("Delete")
+                    .accessibilityLabel("Delete")
                 }
             }
 
@@ -181,12 +185,16 @@ struct AppBarItemRowView: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
+            .help("Edit")
+            .accessibilityLabel("Edit")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
+            .help("Delete")
+            .accessibilityLabel("Delete")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
@@ -256,12 +264,16 @@ struct WebsiteLinkRowView: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
+            .help("Edit")
+            .accessibilityLabel("Edit")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
+            .help("Delete")
+            .accessibilityLabel("Delete")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)


### PR DESCRIPTION
💡 **What**: Added `.help()` tooltips and `.accessibilityLabel()` modifiers to the icon-only Edit and Delete buttons in the On-Screen Keyboard settings.
🎯 **Why**: Without tooltips or ARIA labels, icon-only buttons can be ambiguous for some users and completely opaque to screen readers like VoiceOver, degrading accessibility.
♿ **Accessibility**: VoiceOver will now announce "Edit" or "Delete", and hover users will get helpful context popups.

---
*PR created automatically by Jules for task [15744758435993663324](https://jules.google.com/task/15744758435993663324) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Added help text and accessibility labels to icon-only action buttons (Edit and Delete) across the on-screen keyboard settings interface, including quick text entries, app bar items, and website link configurations, enhancing usability for users with assistive technologies.

**Documentation**
- Updated development notes documenting accessibility label requirements for icon-only buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->