### PR TITLE
🎨 Palette: Add accessibility modifiers to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-02 - Add missing accessibility modifiers to macOS icon-only buttons
+**Learning:** Icon-only buttons (`Button(action:)` with just an `Image(systemName:)`) in SwiftUI macOS applications often miss tooltips and screen reader labels, particularly in list rows and configuration views. This creates a confusing experience for screen reader users and those navigating with mice who rely on hover tooltips to understand icons.
+**Action:** Always add both `.help()` for hover tooltips and `.accessibilityLabel()` for screen readers to icon-only buttons, especially in common components like edit/delete lists.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
@@ -175,6 +175,8 @@ struct CommandWheelActionRow: View {
             }
             .buttonStyle(.plain)
             .foregroundColor(.secondary)
+            .help("Edit item")
+            .accessibilityLabel("Edit command wheel item")
 
             // Delete button
             Button(action: onDelete) {
@@ -183,6 +185,8 @@ struct CommandWheelActionRow: View {
             }
             .buttonStyle(.plain)
             .foregroundColor(.secondary)
+            .help("Delete item")
+            .accessibilityLabel("Delete command wheel item")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 6)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
@@ -57,6 +57,8 @@ struct LinkedAppsSheet: View {
                                     .foregroundColor(.red)
                             }
                             .buttonStyle(.borderless)
+                            .help("Remove linked app")
+                            .accessibilityLabel("Remove linked app")
                         }
                         .padding(.vertical, 4)
                     }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
@@ -106,12 +106,16 @@ struct QuickTextRowView<SuggestionsView: View>: View {
                         Image(systemName: "pencil")
                     }
                     .buttonStyle(.borderless)
+                    .help("Edit")
+                    .accessibilityLabel("Edit")
 
                     Button(action: onDelete) {
                         Image(systemName: "trash")
                             .foregroundColor(.red)
                     }
                     .buttonStyle(.borderless)
+                    .help("Delete")
+                    .accessibilityLabel("Delete")
                 }
             }
 
@@ -181,12 +185,16 @@ struct AppBarItemRowView: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
+            .help("Edit")
+            .accessibilityLabel("Edit")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
+            .help("Delete")
+            .accessibilityLabel("Delete")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
@@ -256,12 +264,16 @@ struct WebsiteLinkRowView: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
+            .help("Edit")
+            .accessibilityLabel("Edit")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
+            .help("Delete")
+            .accessibilityLabel("Delete")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)


### PR DESCRIPTION
🎨 Palette: [UX improvement]

* 💡 What: Added `.help()` tooltips and `.accessibilityLabel()` attributes to icon-only Edit and Delete buttons across three key configuration views (CommandWheelSettingsView, LinkedAppsSheet, and OnScreenKeyboardSettingsView).
* 🎯 Why: Without text labels, screen readers announce these buttons simply as "Button", and mouse users get no hover context, causing confusion during configuration tasks.
* 📸 Before/After: Visual changes are limited to a new tooltip when hovering over the pencil or trash icons.
* ♿ Accessibility: Screen reader users can now hear "Edit" or "Delete" (with appropriate context) when navigating lists, and mouse users can discover actions via standard macOS tooltips.

---
*PR created automatically by Jules for task [16912691268721827003](https://jules.google.com/task/16912691268721827003) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips and accessibility labels to Edit, Delete, and Remove action buttons throughout the application's settings views for improved user guidance

* **Documentation**
  * Added accessibility best practices reference documentation for button components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->