### PR TITLE
🎨 Palette: Add help tooltips to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Accessibility standards for icon-only buttons
+**Learning:** In SwiftUI macOS apps, icon-only buttons (like edit or trash icons in lists) require both `.help()` tooltips for sighted mouse users and `.accessibilityLabel()` for screen reader users to be fully accessible and understandable.
+**Action:** Add `.help("Label")` to all icon-only buttons that currently only have `.accessibilityLabel()`.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -104,6 +104,7 @@ struct MacroRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Edit")
+                .help("Edit")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
@@ -111,6 +112,7 @@ struct MacroRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Delete")
+                .help("Delete")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -116,6 +116,7 @@ struct ChordRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Edit")
+                .help("Edit")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
@@ -123,6 +124,7 @@ struct ChordRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Delete")
+                .help("Delete")
             }
         }
         .padding(.horizontal, 12)
@@ -260,6 +262,7 @@ struct SequenceRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Edit")
+                .help("Edit")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
@@ -267,6 +270,7 @@ struct SequenceRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Delete")
+                .help("Delete")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/GestureListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/GestureListViews.swift
@@ -79,6 +79,7 @@ struct GestureRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Edit")
+                .help("Edit")
 
                 if mapping?.hasAction == true {
                     Button(action: onClear) {
@@ -87,6 +88,7 @@ struct GestureRow: View {
                     }
                     .buttonStyle(.borderless)
                     .accessibilityLabel("Clear")
+                    .help("Clear")
                 }
             }
         }

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -223,6 +223,7 @@ struct ScriptRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Edit")
+                .help("Edit")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
@@ -230,6 +231,7 @@ struct ScriptRow: View {
                 }
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Delete")
+                .help("Delete")
             }
         }
         .padding(.horizontal, 12)


### PR DESCRIPTION
💡 **What:** Added `.help()` tooltips to icon-only buttons (like Edit, Delete, Clear) in `MacroListView`, `ScriptListView`, `GestureListViews`, and `ChordSequenceListViews`.
🎯 **Why:** To provide crucial context for sighted mouse users who rely on hover states to understand icon functionalities.
♿ **Accessibility:** This works in tandem with the existing `.accessibilityLabel()` properties to ensure complete UX/accessibility for all users.

---
*PR created automatically by Jules for task [15704587393223550599](https://jules.google.com/task/15704587393223550599) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved accessibility by adding helpful tooltips to action buttons throughout the application, providing clearer guidance for editing, deleting, and clearing items in lists, macros, chords, gestures, and scripts.

* **Documentation**
  * Updated accessibility guidelines with recommendations for implementing icon-only buttons in macOS applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->