### PR TITLE
🎨 Palette: Add missing tooltips and accessibility labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-03 - Missing tooltips and accessibility on list item actions
 **Learning:** Icon-only buttons used for item actions (like 'Edit', 'Delete', 'Remove') within list views often lack tooltips and accessibility labels. This omission makes the UI ambiguous for mouse users on macOS and inaccessible to screen readers.
 **Action:** Always add `.help("Action Name")` and `.accessibilityLabel("Action Name Item Type")` to icon-only buttons, especially those located at the trailing edge of list rows.
+
+## 2024-11-20 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
+**Learning:** In macOS SwiftUI applications, icon-only buttons often have either `.help()` (for hover tooltips) or `.accessibilityLabel()` (for VoiceOver), but frequently lack both. Both are necessary because they serve different user interaction models—`.help` for visual hover feedback and `.accessibilityLabel` for screen readers.
+**Action:** When adding or reviewing icon-only buttons in SwiftUI, always ensure symmetry by defining both `.help("Description")` and `.accessibilityLabel("Description")` to cover all accessibility and usability vectors.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroEditorSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroEditorSheet.swift
@@ -286,6 +286,7 @@ struct MacroStepRow: View {
             }
             .buttonStyle(.plain)
             .help("Duplicate step")
+            .accessibilityLabel("Duplicate step")
 
             Button {
                 onDelete()
@@ -296,6 +297,7 @@ struct MacroStepRow: View {
             }
             .buttonStyle(.plain)
             .help("Delete step")
+            .accessibilityLabel("Delete step")
 
             Image(systemName: "chevron.right")
                 .font(.caption)
@@ -645,7 +647,10 @@ struct MacroStepEditorSheet: View {
                                 Text(webhookHeaders[key] ?? "").font(.caption).foregroundColor(.secondary)
                                 Button { webhookHeaders.removeValue(forKey: key) } label: {
                                     Image(systemName: "minus.circle.fill").foregroundColor(.red)
-                                }.buttonStyle(.plain)
+                                }
+                                .buttonStyle(.plain)
+                                .help("Remove header")
+                                .accessibilityLabel("Remove header")
                             }
                         }
                         HStack {
@@ -663,6 +668,8 @@ struct MacroStepEditorSheet: View {
                                 Image(systemName: "plus.circle.fill").foregroundColor(.green)
                             }
                             .buttonStyle(.plain)
+                            .help("Add header")
+                            .accessibilityLabel("Add header")
                             .disabled(newWebhookHeaderKey.isEmpty)
                         }
                     }

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -103,6 +103,7 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
+                .help("Edit")
                 .accessibilityLabel("Edit")
 
                 Button(action: onDelete) {
@@ -110,6 +111,7 @@ struct MacroRow: View {
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
+                .help("Delete")
                 .accessibilityLabel("Delete")
             }
         }

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,6 +222,7 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
+                .help("Edit")
                 .accessibilityLabel("Edit")
 
                 Button(action: onDelete) {
@@ -229,6 +230,7 @@ struct ScriptRow: View {
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
+                .help("Delete")
                 .accessibilityLabel("Delete")
             }
         }


### PR DESCRIPTION
💡 What: Added missing `.help()` and `.accessibilityLabel()` modifiers to icon-only buttons across `MacroListView`, `ScriptListView`, and `MacroEditorSheet`.
🎯 Why: To ensure feature parity between hover tooltips (for mouse users) and voiceover announcements (for screen reader users) so that icon-only actions like edit, delete, and duplicate are accessible to everyone.
📸 Before/After: Not applicable (invisible code changes).
♿ Accessibility: Symmetrically applies tooltips and a11y labels across the interface.

---
*PR created automatically by Jules for task [6129862362620885045](https://jules.google.com/task/6129862362620885045) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated accessibility guidance for icon-only list item actions to ensure consistent hover tooltips and screen reader descriptions.

* **Bug Fixes**
  * Added missing accessibility labels and hover tooltips to Edit, Delete, and action buttons across macro and script management interfaces.
  * Enhanced webhook header controls with accessibility support for improved screen reader compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->