### PR TITLE
Revert "⚡ Cache DateFormatter in ConfigBackupService for Performance"

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Services/Profile/ConfigBackupService.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Profile/ConfigBackupService.swift
@@ -3,12 +3,6 @@ import Foundation
 struct ConfigBackupService {
     private let fileManager: FileManager
 
-    private static let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
-        return formatter
-    }()
-
     init(fileManager: FileManager = .default) {
         self.fileManager = fileManager
     }
@@ -27,7 +21,9 @@ struct ConfigBackupService {
             return
         }
 
-        let timestamp = Self.dateFormatter.string(from: Date())
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd_HH-mm-ss"
+        let timestamp = dateFormatter.string(from: Date())
         let backupURL = backupDir.appendingPathComponent("config_\(timestamp).json")
 
         do {


### PR DESCRIPTION
Reverts NSEvent/xbox-controller-mapper#30

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal implementation of the backup configuration service to enhance code maintainability and consistency with best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->