### PR TITLE
🎨 Palette: Add accessibility labels and tooltips to icon-only buttons in OnScreenKeyboardSettingsView

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
@@ -106,12 +106,16 @@ struct QuickTextRowView<SuggestionsView: View>: View {
                         Image(systemName: "pencil")
                     }
                     .buttonStyle(.borderless)
+                    .help("Edit quick text")
+                    .accessibilityLabel("Edit quick text")
 
                     Button(action: onDelete) {
                         Image(systemName: "trash")
                             .foregroundColor(.red)
                     }
                     .buttonStyle(.borderless)
+                    .help("Delete quick text")
+                    .accessibilityLabel("Delete quick text")
                 }
             }
 
@@ -181,12 +185,16 @@ struct AppBarItemRowView: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
+            .help("Edit app")
+            .accessibilityLabel("Edit app")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
+            .help("Delete app")
+            .accessibilityLabel("Delete app")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
@@ -256,12 +264,16 @@ struct WebsiteLinkRowView: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
+            .help("Edit link")
+            .accessibilityLabel("Edit link")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
+            .help("Delete link")
+            .accessibilityLabel("Delete link")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)


### PR DESCRIPTION
💡 **What:** Added `.help()` (tooltips) and `.accessibilityLabel()` to icon-only buttons (Edit/Delete) inside `QuickTextRowView`, `AppBarItemRowView`, and `WebsiteLinkRowView` within `OnScreenKeyboardSettingsView.swift`.
🎯 **Why:** To improve accessibility for screen readers and usability for macOS users who rely on hover tooltips, preventing ambiguity about what the buttons do.
📸 **Before/After:** No visual changes except when hovering over the buttons or when using VoiceOver.
♿ **Accessibility:** Users can now navigate these list items via VoiceOver and know exactly what actions are available without guessing from icon semantics alone.

---
*PR created automatically by Jules for task [2840446562854567091](https://jules.google.com/task/2840446562854567091) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility support with improved screen reader labels for edit and delete buttons throughout the application, making navigation more intuitive for users with assistive devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->