### PR TITLE
🎨 Palette: Improve accessibility and tooltips for icon-only close buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,6 @@
 ## 2024-11-20 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
 **Learning:** In macOS SwiftUI applications, icon-only buttons often have either `.help()` (for hover tooltips) or `.accessibilityLabel()` (for VoiceOver), but frequently lack both. Both are necessary because they serve different user interaction models—`.help` for visual hover feedback and `.accessibilityLabel` for screen readers.
 **Action:** When adding or reviewing icon-only buttons in SwiftUI, always ensure symmetry by defining both `.help("Description")` and `.accessibilityLabel("Description")` to cover all accessibility and usability vectors.
+## 2026-06-06 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
+**Learning:** In macOS SwiftUI applications, icon-only buttons often have either `.help()` (for hover tooltips) or `.accessibilityLabel()` (for VoiceOver), but frequently lack both. Both are necessary because they serve different user interaction models—`.help` for visual hover feedback and `.accessibilityLabel` for screen readers.
+**Action:** When adding or reviewing icon-only buttons in SwiftUI, always ensure symmetry by defining both `.help("Description")` and `.accessibilityLabel("Description")` to cover all accessibility and usability vectors.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Components/BookmarkPickerSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Components/BookmarkPickerSheet.swift
@@ -46,6 +46,8 @@ struct BookmarkPickerSheet: View {
                             .foregroundColor(.secondary)
                     }
                     .buttonStyle(.plain)
+                    .help("Clear search")
+                    .accessibilityLabel("Clear search")
                 }
             }
             .padding(8)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyCaptureField.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Components/KeyCaptureField.swift
@@ -22,6 +22,7 @@ struct KeyCaptureField: View {
                         .foregroundColor(.secondary)
                 }
                 .buttonStyle(.plain)
+                .help("Clear shortcut")
                 .accessibilityLabel("Clear shortcut")
             }
         }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
@@ -274,6 +274,8 @@ struct ButtonMappingSheet: View {
                     .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
+            .help("Close")
+            .accessibilityLabel("Close")
         }
         .padding(16)
     }


### PR DESCRIPTION
🎨 Palette here! I've added a micro-UX improvement to the interface.

💡 **What:** Added missing `.help("...")` tooltips and `.accessibilityLabel("...")` modifiers to icon-only close/clear buttons (using `xmark.circle.fill`) across several views (`BookmarkPickerSheet`, `KeyCaptureField`, and `ButtonMappingSheet`).

🎯 **Why:** Icon-only buttons without tooltips leave mouse users guessing what the button does. Without an accessibility label, screen reader users (VoiceOver) just hear "button" with no context. This change ensures symmetry between hover tooltips and accessibility labels, making the UI more intuitive and accessible for all users.

📸 **Before/After:** Not a visual layout change, but on hover, users will now see "Clear search", "Clear shortcut", or "Close" tooltips, and VoiceOver will read these descriptions aloud.

♿ **Accessibility:** Added `.accessibilityLabel` to instances where it was missing, ensuring all these interactive elements are properly identified by screen readers.

---
*PR created automatically by Jules for task [3486360866344041444](https://jules.google.com/task/3486360866344041444) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced accessibility across multiple components by adding descriptive help text and voice-over labels to icon-only buttons.

* **Documentation**
  * Updated accessibility guidelines documentation with best practices for icon-only button implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->