### PR TITLE
Add custom mouse scroll mappings

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/InputSimulator.swift
@@ -292,7 +292,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
         // Handle scroll action "key codes"
         if KeyCodeMapping.isScrollAction(keyCode) {
-            performScrollAction(keyCode)
+            performScrollAction(keyCode, modifiers: modifiers)
             return
         }
 
@@ -430,7 +430,7 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
         }
 
         if KeyCodeMapping.isScrollAction(keyCode) {
-            performScrollAction(keyCode)
+            performScrollAction(keyCode, modifiers: modifiers)
             return
         }
 
@@ -1626,9 +1626,10 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
 
     // MARK: - Scroll Action Simulation
 
-    private func performScrollAction(_ keyCode: CGKeyCode) {
-        let dy: CGFloat = keyCode == KeyCodeMapping.scrollUp ? 10 : -10
-        scroll(event: ScrollEvent(dx: 0, dy: dy))
+    private func performScrollAction(_ keyCode: CGKeyCode, modifiers: CGEventFlags = []) {
+        let amount: CGFloat = 10
+        let delta = KeyCodeMapping.scrollDelta(for: keyCode, amount: amount)
+        scroll(event: ScrollEvent(dx: delta.dx, dy: delta.dy, flags: modifiers))
     }
 
     // MARK: - Mouse Button Simulation
@@ -1973,6 +1974,10 @@ class InputSimulator: InputSimulatorProtocol, @unchecked Sendable {
             return (down ? .rightMouseDown : .rightMouseUp, .right)
         case KeyCodeMapping.mouseMiddleClick:
             return (down ? .otherMouseDown : .otherMouseUp, .center)
+        case KeyCodeMapping.mouseBackClick:
+            return (down ? .otherMouseDown : .otherMouseUp, CGMouseButton(rawValue: 3) ?? .center)
+        case KeyCodeMapping.mouseForwardClick:
+            return (down ? .otherMouseDown : .otherMouseUp, CGMouseButton(rawValue: 4) ?? .center)
         default:
             return (down ? .leftMouseDown : .leftMouseUp, .left)
         }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -438,6 +438,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
 		remoteSessionReceivedCursorStatus = false
         activeHandoffZone = nil
         pendingHandoffPortal = nil
+        remoteControllerInputRoutingGraceUntil = Date.distantPast
         remoteFocusModeSent = nil
 		resetRemoteCursorVisibilityRestoreStateLocked()
         outgoingRemoteMouseButtonsHeld.removeAll()

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -325,6 +325,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
     private var didLogFirstReceive = false
     private var lastHandoffSkipLog = Date.distantPast
     private var remoteHandoffSuppressedUntil = Date.distantPast
+    private var remoteControllerInputRoutingGraceUntil = Date.distantPast
     private var lastRemoteCursorVisibilityRestoreAt: CFTimeInterval?
 
     var canSendToRemote: Bool {
@@ -372,6 +373,12 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
 		)
     }
 
+    var shouldRouteControllerInputToRemote: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return isRemoteSessionActive || Date() < remoteControllerInputRoutingGraceUntil
+    }
+
     var isOutgoingRemoteLeftMouseButtonHeld: Bool {
         lock.lock()
         defer { lock.unlock() }
@@ -405,6 +412,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
 			remoteSessionReceivedCursorStatus = false
             activeHandoffZone = nil
             pendingHandoffPortal = nil
+            remoteControllerInputRoutingGraceUntil = Date.distantPast
             remoteFocusModeSent = nil
 			resetRemoteCursorVisibilityRestoreStateLocked()
             outgoingRemoteMouseButtonsHeld.removeAll()
@@ -451,6 +459,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         activeHandoffZone = zone
 		remoteCursorStatus = nil
 		remoteSessionReceivedCursorStatus = false
+        remoteControllerInputRoutingGraceUntil = Date().addingTimeInterval(UniversalControlRelaySessionPolicy.confirmationTimeout)
 		resetRemoteCursorVisibilityRestoreStateLocked()
         isRemoteSessionActive = true
         lock.unlock()
@@ -2626,6 +2635,10 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
             return (down ? .rightMouseDown : .rightMouseUp, .right)
         case KeyCodeMapping.mouseMiddleClick:
             return (down ? .otherMouseDown : .otherMouseUp, .center)
+        case KeyCodeMapping.mouseBackClick:
+            return (down ? .otherMouseDown : .otherMouseUp, CGMouseButton(rawValue: 3) ?? .center)
+        case KeyCodeMapping.mouseForwardClick:
+            return (down ? .otherMouseDown : .otherMouseUp, CGMouseButton(rawValue: 4) ?? .center)
         default:
             return (down ? .leftMouseDown : .leftMouseUp, .left)
         }

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/JoystickHandler.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/JoystickHandler.swift
@@ -617,23 +617,103 @@ extension MappingEngine {
 				settings: settings
 			)
         updateHeldDirectionButtons(targetButtons, heldButtons: &heldButtons)
+		processCustomDirectionScrollActions(targetButtons, stick: stick, side: side, settings: settings)
     }
 
 	nonisolated private func customDirectionMappingsUseAxisMovement(side: JoystickSide) -> Bool {
 		guard let profile = state.activeProfile else { return false }
 
-		return ControllerButton.joystickDirectionButtons(side: side).allSatisfy { button in
+		return StickDirectionPreset.allCases.contains { preset in
+			ControllerButton.joystickDirectionButtons(side: side).allSatisfy { button in
+				guard let direction = button.joystickDirection,
+					  let expectedKeyCode = preset.primaryKeyCode(for: direction),
+					  let mapping = ButtonMappingResolutionPolicy.resolve(
+						button: button,
+						profile: profile,
+						activeLayerIds: state.activeLayerIds,
+						layerActivatorMap: state.layerActivatorMap
+					  ) else {
+					return false
+				}
+
+				return mapping.isJoystickAxisMovementMapping(expectedKeyCode: expectedKeyCode)
+			}
+		}
+	}
+
+	nonisolated private func processCustomDirectionScrollActions(
+		_ targetButtons: Set<ControllerButton>,
+		stick: CGPoint,
+		side: JoystickSide,
+		settings: JoystickSettings
+	) {
+		guard let profile = state.activeProfile else { return }
+
+		for button in targetButtons {
 			guard let mapping = ButtonMappingResolutionPolicy.resolve(
 				button: button,
 				profile: profile,
 				activeLayerIds: state.activeLayerIds,
 				layerActivatorMap: state.layerActivatorMap
-			) else {
-				return false
+			),
+				  mapping.effectiveActionType == .keyPress,
+				  let keyCode = mapping.keyCode,
+				  KeyCodeMapping.isScrollAction(keyCode),
+				  let amount = customDirectionScrollAmount(button: button, stick: stick, side: side, settings: settings)
+			else {
+				continue
 			}
 
-			return mapping.isJoystickAxisMovementMapping
+			let delta = KeyCodeMapping.scrollDelta(for: keyCode, amount: amount)
+			guard delta.dx != 0 || delta.dy != 0 else { continue }
+
+			let flags = inputSimulator.getHeldModifiers().union(mapping.modifiers.cgEventFlags)
+			inputSimulator.scroll(
+				event: ScrollEvent(
+					dx: delta.dx,
+					dy: delta.dy,
+					phase: nil,
+					momentumPhase: nil,
+					isContinuous: true,
+					flags: flags
+				)
+			)
+			usageStatsService?.recordScrollDistance(dx: Double(delta.dx), dy: Double(delta.dy))
 		}
+	}
+
+	nonisolated private func customDirectionScrollAmount(
+		button: ControllerButton,
+		stick: CGPoint,
+		side: JoystickSide,
+		settings: JoystickSettings
+	) -> CGFloat? {
+		guard let direction = button.joystickDirection else { return nil }
+
+		let deadzone: Double
+		switch side {
+		case .left:
+			deadzone = settings.leftStickCustomDeadzone
+		case .right:
+			deadzone = settings.rightStickCustomDeadzone
+		}
+
+		let axisMagnitude: Double
+		switch direction {
+		case .up, .down:
+			axisMagnitude = abs(Double(stick.y))
+		case .left, .right:
+			axisMagnitude = abs(Double(stick.x))
+		case .upLeft, .upRight, .downLeft, .downRight:
+			axisMagnitude = sqrt(Double(stick.x * stick.x + stick.y * stick.y))
+		}
+
+		guard axisMagnitude > deadzone else { return nil }
+		let normalized = min(1.0, max(0.0, JoystickMath.normalizedMagnitude(axisMagnitude, deadzone: deadzone)))
+		let accelerated = pow(normalized, settings.scrollAccelerationExponent)
+		let amount = accelerated * settings.scrollMultiplier
+		guard amount > 0 else { return nil }
+		return CGFloat(amount)
 	}
 
     nonisolated private func updateHeldDirectionButtons(
@@ -689,8 +769,8 @@ extension MappingEngine {
 }
 
 private extension KeyMapping {
-	var isJoystickAxisMovementMapping: Bool {
-		keyCode != nil
+	func isJoystickAxisMovementMapping(expectedKeyCode: CGKeyCode) -> Bool {
+		keyCode == expectedKeyCode
 			&& modifiers == ModifierFlags()
 			&& macroId == nil
 			&& scriptId == nil

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/JoystickHandler.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/JoystickHandler.swift
@@ -623,21 +623,17 @@ extension MappingEngine {
 	nonisolated private func customDirectionMappingsUseAxisMovement(side: JoystickSide) -> Bool {
 		guard let profile = state.activeProfile else { return false }
 
-		return StickDirectionPreset.allCases.contains { preset in
-			ControllerButton.joystickDirectionButtons(side: side).allSatisfy { button in
-				guard let direction = button.joystickDirection,
-					  let expectedKeyCode = preset.primaryKeyCode(for: direction),
-					  let mapping = ButtonMappingResolutionPolicy.resolve(
-						button: button,
-						profile: profile,
-						activeLayerIds: state.activeLayerIds,
-						layerActivatorMap: state.layerActivatorMap
-					  ) else {
-					return false
-				}
-
-				return mapping.isJoystickAxisMovementMapping(expectedKeyCode: expectedKeyCode)
+		return ControllerButton.joystickDirectionButtons(side: side).allSatisfy { button in
+			guard let mapping = ButtonMappingResolutionPolicy.resolve(
+				button: button,
+				profile: profile,
+				activeLayerIds: state.activeLayerIds,
+				layerActivatorMap: state.layerActivatorMap
+			) else {
+				return false
 			}
+
+			return mapping.isJoystickAxisMovementMapping
 		}
 	}
 
@@ -769,8 +765,8 @@ extension MappingEngine {
 }
 
 private extension KeyMapping {
-	func isJoystickAxisMovementMapping(expectedKeyCode: CGKeyCode) -> Bool {
-		keyCode == expectedKeyCode
+	var isJoystickAxisMovementMapping: Bool {
+		keyCode != nil
 			&& modifiers == ModifierFlags()
 			&& macroId == nil
 			&& scriptId == nil

--- a/XboxControllerMapper/XboxControllerMapper/Services/Mapping/MappingEngine.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Mapping/MappingEngine.swift
@@ -648,7 +648,7 @@ class MappingEngine: ObservableObject {
     nonisolated private func handleButtonPressed(_ button: ControllerButton) {
         dispatchPrecondition(condition: .onQueue(inputQueue))
         LatencyDiagnostics.mark("engine.press \(button.rawValue)")
-		if UniversalControlMouseRelay.shared.isRoutingToRemote {
+		if UniversalControlMouseRelay.shared.shouldRouteControllerInputToRemote {
             _ = UniversalControlMouseRelay.shared.sendControllerButtonPressed(button)
             return
         }
@@ -1217,7 +1217,7 @@ class MappingEngine: ObservableObject {
         dispatchPrecondition(condition: .onQueue(inputQueue))
         LatencyDiagnostics.mark("engine.release \(button.rawValue)")
 		let resolvedButtonForState = peekResolvedReleaseButton(for: button)
-		if UniversalControlMouseRelay.shared.isRoutingToRemote {
+		if UniversalControlMouseRelay.shared.shouldRouteControllerInputToRemote {
 			let hasLocalButtonState = state.lock.withLock {
 				state.heldButtons[resolvedButtonForState] != nil
 					|| state.pendingSingleTap[resolvedButtonForState] != nil
@@ -1529,7 +1529,7 @@ class MappingEngine: ObservableObject {
     /// - Precondition: Must be called on inputQueue
     nonisolated private func handleChord(_ buttons: Set<ControllerButton>) {
         dispatchPrecondition(condition: .onQueue(inputQueue))
-		if UniversalControlMouseRelay.shared.isRoutingToRemote {
+		if UniversalControlMouseRelay.shared.shouldRouteControllerInputToRemote {
             _ = UniversalControlMouseRelay.shared.sendControllerChord(buttons)
             return
         }

--- a/XboxControllerMapper/XboxControllerMapper/Utilities/KeyCodeMapping.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Utilities/KeyCodeMapping.swift
@@ -119,6 +119,10 @@ enum KeyCodeMapping {
     static let mouseMiddleClick: CGKeyCode = 0xF002
     static let scrollUp: CGKeyCode = 0xF003
     static let scrollDown: CGKeyCode = 0xF004
+    static let scrollLeft: CGKeyCode = 0xF005
+    static let scrollRight: CGKeyCode = 0xF006
+    static let mouseBackClick: CGKeyCode = 0xF007
+    static let mouseForwardClick: CGKeyCode = 0xF008
 
     // MARK: - Special Action Markers
 
@@ -277,6 +281,10 @@ enum KeyCodeMapping {
         case 0xF002: return "Middle Click"
         case 0xF003: return "Scroll Up"
         case 0xF004: return "Scroll Down"
+        case 0xF005: return "Scroll Left"
+        case 0xF006: return "Scroll Right"
+        case 0xF007: return "Back Button"
+        case 0xF008: return "Forward Button"
 
         // Special actions
         case 0xF010: return "On-Screen Keyboard"
@@ -385,6 +393,10 @@ enum KeyCodeMapping {
         options.append(("Middle Click", mouseMiddleClick))
         options.append(("Scroll Up", scrollUp))
         options.append(("Scroll Down", scrollDown))
+        options.append(("Scroll Left", scrollLeft))
+        options.append(("Scroll Right", scrollRight))
+        options.append(("Back Button", mouseBackClick))
+        options.append(("Forward Button", mouseForwardClick))
 
         // Special actions
         options.append(("On-Screen Keyboard", showOnScreenKeyboard))
@@ -413,12 +425,34 @@ enum KeyCodeMapping {
 
     /// Checks if a key code represents a mouse button
     static func isMouseButton(_ keyCode: CGKeyCode) -> Bool {
-        keyCode == mouseLeftClick || keyCode == mouseRightClick || keyCode == mouseMiddleClick
+        keyCode == mouseLeftClick ||
+        keyCode == mouseRightClick ||
+        keyCode == mouseMiddleClick ||
+        keyCode == mouseBackClick ||
+        keyCode == mouseForwardClick
     }
 
     /// Checks if a key code represents a scroll action
     static func isScrollAction(_ keyCode: CGKeyCode) -> Bool {
-        keyCode == scrollUp || keyCode == scrollDown
+        keyCode == scrollUp ||
+        keyCode == scrollDown ||
+        keyCode == scrollLeft ||
+        keyCode == scrollRight
+    }
+
+    static func scrollDelta(for keyCode: CGKeyCode, amount: CGFloat) -> (dx: CGFloat, dy: CGFloat) {
+        switch keyCode {
+        case scrollUp:
+            return (0, amount)
+        case scrollDown:
+            return (0, -amount)
+        case scrollLeft:
+            return (amount, 0)
+        case scrollRight:
+            return (-amount, 0)
+        default:
+            return (0, 0)
+        }
     }
 
     /// Checks if a key code represents a special action (on-screen keyboard, etc.)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Components/MouseVisualView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Components/MouseVisualView.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+import CoreGraphics
+
+struct MouseVisualView: View {
+    @Binding var selectedKeyCode: CGKeyCode?
+    @Binding var modifiers: ModifierFlags
+
+    @State private var hoveredKey: CGKeyCode?
+
+    var body: some View {
+        VStack(spacing: 14) {
+            HStack(alignment: .top, spacing: 18) {
+                mouseBody
+                scrollPad
+                sideButtons
+            }
+
+            modifierRow
+        }
+        .padding()
+        .background(Color(nsColor: .windowBackgroundColor))
+        .cornerRadius(12)
+    }
+
+    private var mouseBody: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 6) {
+                MouseActionButton(
+                    keyCode: KeyCodeMapping.mouseLeftClick,
+                    systemImage: "cursorarrow",
+                    label: "Left",
+                    width: 90,
+                    height: 64,
+                    selectedKeyCode: $selectedKeyCode,
+                    hoveredKey: $hoveredKey
+                )
+                MouseActionButton(
+                    keyCode: KeyCodeMapping.mouseMiddleClick,
+                    systemImage: "circle.fill",
+                    label: "Middle",
+                    width: 72,
+                    height: 64,
+                    selectedKeyCode: $selectedKeyCode,
+                    hoveredKey: $hoveredKey
+                )
+                MouseActionButton(
+                    keyCode: KeyCodeMapping.mouseRightClick,
+                    systemImage: "cursorarrow",
+                    label: "Right",
+                    width: 90,
+                    height: 64,
+                    selectedKeyCode: $selectedKeyCode,
+                    hoveredKey: $hoveredKey
+                )
+            }
+
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .frame(width: 274, height: 72)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(Color.gray.opacity(0.25), lineWidth: 1)
+                )
+        }
+    }
+
+    private var scrollPad: some View {
+        VStack(spacing: 6) {
+            MouseActionButton(
+                keyCode: KeyCodeMapping.scrollUp,
+                systemImage: "arrow.up",
+                label: "Scroll Up",
+                width: 112,
+                height: 42,
+                selectedKeyCode: $selectedKeyCode,
+                hoveredKey: $hoveredKey
+            )
+
+            HStack(spacing: 6) {
+                MouseActionButton(
+                    keyCode: KeyCodeMapping.scrollLeft,
+                    systemImage: "arrow.left",
+                    label: "Left",
+                    width: 72,
+                    height: 48,
+                    selectedKeyCode: $selectedKeyCode,
+                    hoveredKey: $hoveredKey
+                )
+                MouseActionButton(
+                    keyCode: KeyCodeMapping.scrollRight,
+                    systemImage: "arrow.right",
+                    label: "Right",
+                    width: 72,
+                    height: 48,
+                    selectedKeyCode: $selectedKeyCode,
+                    hoveredKey: $hoveredKey
+                )
+            }
+
+            MouseActionButton(
+                keyCode: KeyCodeMapping.scrollDown,
+                systemImage: "arrow.down",
+                label: "Scroll Down",
+                width: 112,
+                height: 42,
+                selectedKeyCode: $selectedKeyCode,
+                hoveredKey: $hoveredKey
+            )
+        }
+    }
+
+    private var sideButtons: some View {
+        VStack(spacing: 8) {
+            MouseActionButton(
+                keyCode: KeyCodeMapping.mouseBackClick,
+                systemImage: "arrow.uturn.backward",
+                label: "Back",
+                width: 104,
+                height: 54,
+                selectedKeyCode: $selectedKeyCode,
+                hoveredKey: $hoveredKey
+            )
+            MouseActionButton(
+                keyCode: KeyCodeMapping.mouseForwardClick,
+                systemImage: "arrow.uturn.forward",
+                label: "Forward",
+                width: 104,
+                height: 54,
+                selectedKeyCode: $selectedKeyCode,
+                hoveredKey: $hoveredKey
+            )
+        }
+    }
+
+    private var modifierRow: some View {
+        HStack(spacing: 16) {
+            ModifierToggle(label: "⌘ Command", isOn: $modifiers.command, side: $modifiers.commandSide)
+            ModifierToggle(label: "⌥ Option", isOn: $modifiers.option, side: $modifiers.optionSide)
+            ModifierToggle(label: "⇧ Shift", isOn: $modifiers.shift, side: $modifiers.shiftSide)
+            ModifierToggle(label: "⌃ Control", isOn: $modifiers.control, side: $modifiers.controlSide)
+
+            Spacer()
+
+            if selectedKeyCode != nil || modifiers.hasAny {
+                Button("Clear") {
+                    selectedKeyCode = nil
+                    modifiers = ModifierFlags()
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.red)
+            }
+        }
+        .padding(.top, 4)
+    }
+}
+
+private struct MouseActionButton: View {
+    let keyCode: CGKeyCode
+    let systemImage: String
+    let label: String
+    let width: CGFloat
+    let height: CGFloat
+
+    @Binding var selectedKeyCode: CGKeyCode?
+    @Binding var hoveredKey: CGKeyCode?
+
+    var body: some View {
+        Button {
+            selectedKeyCode = keyCode
+        } label: {
+            VStack(spacing: 5) {
+                Image(systemName: systemImage)
+                    .font(.system(size: 14, weight: .semibold))
+                Text(label)
+                    .font(.system(size: label.count > 8 ? 9 : 11, weight: .medium))
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            }
+            .frame(width: width, height: height)
+            .background(backgroundColor)
+            .foregroundColor(foregroundColor)
+            .cornerRadius(6)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6)
+                    .stroke(borderColor, lineWidth: isSelected ? 2 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering in
+            hoveredKey = hovering ? keyCode : nil
+        }
+    }
+
+    private var isSelected: Bool {
+        selectedKeyCode == keyCode
+    }
+
+    private var isHovered: Bool {
+        hoveredKey == keyCode
+    }
+
+    private var backgroundColor: Color {
+        if isSelected {
+            return .accentColor
+        } else if isHovered {
+            return Color.accentColor.opacity(0.3)
+        } else {
+            return Color(nsColor: .controlBackgroundColor)
+        }
+    }
+
+    private var foregroundColor: Color {
+        isSelected ? .white : .primary
+    }
+
+    private var borderColor: Color {
+        if isSelected {
+            return .accentColor
+        } else if isHovered {
+            return .accentColor.opacity(0.5)
+        } else {
+            return .gray.opacity(0.3)
+        }
+    }
+}
+
+#Preview {
+    MouseVisualView(selectedKeyCode: .constant(nil), modifiers: .constant(ModifierFlags()))
+}

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ActionMappingEditor.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ActionMappingEditor.swift
@@ -65,13 +65,15 @@ struct ActionMappingEditor: View {
             }
         }
 
-        if state.showingKeyboard {
+        if state.showingMouse {
+            MouseVisualView(selectedKeyCode: $state.keyCode, modifiers: $state.modifiers)
+        } else if state.showingKeyboard {
             KeyboardVisualView(selectedKeyCode: $state.keyCode, modifiers: $state.modifiers)
         } else {
             KeyCaptureField(keyCode: $state.keyCode, modifiers: $state.modifiers)
         }
 
-        if variant == .primary && !state.showingKeyboard {
+        if variant == .primary && !state.showingKeyboard && !state.showingMouse {
             Text("Click to type a shortcut, or show keyboard to select visually")
                 .font(.caption)
                 .foregroundColor(.secondary)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
@@ -349,24 +349,30 @@ struct ButtonMappingSheet: View {
 
     private var primaryMappingSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Primary Action")
-                    .font(.headline)
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Primary Action")
+                        .font(.headline)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
 
-                Spacer()
+                    Spacer()
 
-                Picker("", selection: $primaryState.mappingType) {
-                    Text("Key").tag(MappingEditorState.MappingType.singleKey)
-                    Text("Macro").tag(MappingEditorState.MappingType.macro)
-                    Text("Script").tag(MappingEditorState.MappingType.script)
-                    Text("System").tag(MappingEditorState.MappingType.systemCommand)
+                    Picker("", selection: $primaryState.mappingType) {
+                        Text("Key").tag(MappingEditorState.MappingType.singleKey)
+                        Text("Macro").tag(MappingEditorState.MappingType.macro)
+                        Text("Script").tag(MappingEditorState.MappingType.script)
+                        Text("System").tag(MappingEditorState.MappingType.systemCommand)
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(width: 280)
                 }
-                .pickerStyle(.segmented)
-                .frame(width: 280)
-                .padding(.trailing, 8)
 
                 if primaryState.mappingType == .singleKey {
-                    visualPickerButtons(for: $primaryState)
+                    HStack {
+                        Spacer()
+                        visualPickerButtons(for: $primaryState, compact: true)
+                    }
                 }
             }
 
@@ -602,6 +608,8 @@ struct ButtonMappingSheet: View {
             HStack {
                 Toggle("Enable Long Hold Action", isOn: $enableLongHold)
                     .font(.headline)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
                     .disabled(longHoldDisabled)
 
                 Spacer()
@@ -697,6 +705,8 @@ struct ButtonMappingSheet: View {
             HStack {
                 Toggle("Enable Double Tap Action", isOn: $enableDoubleTap)
                     .font(.headline)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
                     .disabled(primaryDisablesAdvancedFeatures)
 
                 Spacer()

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
@@ -52,6 +52,10 @@ struct ButtonMappingSheet: View {
         primaryState.showingKeyboard || longHoldState.showingKeyboard || doubleTapState.showingKeyboard
     }
 
+    private var showingAnyMouse: Bool {
+        primaryState.showingMouse || longHoldState.showingMouse || doubleTapState.showingMouse
+    }
+
     /// Check if the primary action is a mouse click - disables double tap/long hold
     private var primaryIsMouseClick: Bool {
         guard let code = primaryState.keyCode else { return false }
@@ -183,10 +187,13 @@ struct ButtonMappingSheet: View {
             footer
         }
         .onSubmit { saveMapping() }
-        .frame(width: showingAnyKeyboard ? 850 : (primaryState.mappingType == .systemCommand ? 640 : 600), height: showingAnyKeyboard ? 700 : 550)
+        .frame(width: sheetWidth, height: sheetHeight)
         .animation(.easeInOut(duration: 0.2), value: primaryState.showingKeyboard)
         .animation(.easeInOut(duration: 0.2), value: longHoldState.showingKeyboard)
         .animation(.easeInOut(duration: 0.2), value: doubleTapState.showingKeyboard)
+        .animation(.easeInOut(duration: 0.2), value: primaryState.showingMouse)
+        .animation(.easeInOut(duration: 0.2), value: longHoldState.showingMouse)
+        .animation(.easeInOut(duration: 0.2), value: doubleTapState.showingMouse)
         .animation(.easeInOut(duration: 0.2), value: primaryState.mappingType)
         .onAppear {
             loadCurrentMapping()
@@ -219,6 +226,64 @@ struct ButtonMappingSheet: View {
                 primaryState.selectedScriptId = newScript.id
             })
         }
+    }
+
+    private var sheetWidth: CGFloat {
+        if showingAnyKeyboard { return 850 }
+        if showingAnyMouse { return 760 }
+        return primaryState.mappingType == .systemCommand ? 640 : 600
+    }
+
+    private var sheetHeight: CGFloat {
+        if showingAnyKeyboard { return 700 }
+        if showingAnyMouse { return 620 }
+        return 550
+    }
+
+    private func visualPickerButtons(for state: Binding<MappingEditorState>, compact: Bool = false) -> some View {
+        HStack(spacing: 8) {
+            visualPickerButton(
+                title: state.wrappedValue.showingKeyboard
+                    ? (compact ? "Hide" : "Hide Keyboard")
+                    : (compact ? "Keyboard" : "Show Keyboard"),
+                systemImage: state.wrappedValue.showingKeyboard ? "keyboard.chevron.compact.down" : "keyboard"
+            ) {
+                state.wrappedValue.showingKeyboard.toggle()
+                if state.wrappedValue.showingKeyboard {
+                    state.wrappedValue.showingMouse = false
+                }
+            }
+
+            visualPickerButton(
+                title: state.wrappedValue.showingMouse
+                    ? (compact ? "Hide" : "Hide Mouse")
+                    : (compact ? "Mouse" : "Show Mouse"),
+                systemImage: state.wrappedValue.showingMouse ? "computermouse.fill" : "computermouse"
+            ) {
+                state.wrappedValue.showingMouse.toggle()
+                if state.wrappedValue.showingMouse {
+                    state.wrappedValue.showingKeyboard = false
+                }
+            }
+        }
+    }
+
+    private func visualPickerButton(title: String, systemImage: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                Image(systemName: systemImage)
+                Text(title)
+                    .lineLimit(1)
+            }
+            .font(.callout)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Color.accentColor.opacity(0.1))
+            .cornerRadius(6)
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(.accentColor)
+        .fixedSize()
     }
 
     // MARK: - Header
@@ -301,21 +366,7 @@ struct ButtonMappingSheet: View {
                 .padding(.trailing, 8)
 
                 if primaryState.mappingType == .singleKey {
-                    Button(action: { primaryState.showingKeyboard.toggle() }) {
-                        HStack(spacing: 6) {
-                            Image(systemName: primaryState.showingKeyboard ? "keyboard.chevron.compact.down" : "keyboard")
-                            Text(primaryState.showingKeyboard ? "Hide Keyboard" : "Show Keyboard")
-                                .lineLimit(1)
-                        }
-                        .font(.callout)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(Color.accentColor.opacity(0.1))
-                        .cornerRadius(6)
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundColor(.accentColor)
-                    .fixedSize()
+                    visualPickerButtons(for: $primaryState)
                 }
             }
 
@@ -556,21 +607,7 @@ struct ButtonMappingSheet: View {
                 Spacer()
 
                 if enableLongHold && !longHoldDisabled && longHoldState.mappingType == .singleKey {
-                    Button(action: { longHoldState.showingKeyboard.toggle() }) {
-                        HStack(spacing: 6) {
-                            Image(systemName: longHoldState.showingKeyboard ? "keyboard.chevron.compact.down" : "keyboard")
-                            Text(longHoldState.showingKeyboard ? "Hide" : "Show Keyboard")
-                                .lineLimit(1)
-                        }
-                        .font(.callout)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(Color.accentColor.opacity(0.1))
-                        .cornerRadius(6)
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundColor(.accentColor)
-                    .fixedSize()
+                    visualPickerButtons(for: $longHoldState, compact: true)
                 }
             }
 
@@ -665,21 +702,7 @@ struct ButtonMappingSheet: View {
                 Spacer()
 
                 if enableDoubleTap && !primaryDisablesAdvancedFeatures && doubleTapState.mappingType == .singleKey {
-                    Button(action: { doubleTapState.showingKeyboard.toggle() }) {
-                        HStack(spacing: 6) {
-                            Image(systemName: doubleTapState.showingKeyboard ? "keyboard.chevron.compact.down" : "keyboard")
-                            Text(doubleTapState.showingKeyboard ? "Hide" : "Show Keyboard")
-                                .lineLimit(1)
-                        }
-                        .font(.callout)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(Color.accentColor.opacity(0.1))
-                        .cornerRadius(6)
-                    }
-                    .buttonStyle(.plain)
-                    .foregroundColor(.accentColor)
-                    .fixedSize()
+                    visualPickerButtons(for: $doubleTapState, compact: true)
                 }
             }
 

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/MappingEditorState.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/MappingEditorState.swift
@@ -53,6 +53,7 @@ struct MappingEditorState {
 
     // MARK: - UI state
     var showingKeyboard: Bool = false
+    var showingMouse: Bool = false
     var showingAppPicker: Bool = false
     var showingBookmarkPicker: Bool = false
     var showingMacroCreation: Bool = false

--- a/XboxControllerMapper/XboxControllerMapperTests/JoystickCustomDirectionMappingTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/JoystickCustomDirectionMappingTests.swift
@@ -265,6 +265,38 @@ final class JoystickCustomDirectionMappingTests: XCTestCase {
 		XCTAssertTrue(rightIsActive)
 	}
 
+	func testCustomHeldKeyDirectionsSupportDiagonalMovementOutsidePresets() async throws {
+		await MainActor.run {
+			let mappings: [ControllerButton: KeyMapping] = [
+				.leftStickUp: holdMapping(KeyCodeMapping.keyI),
+				.leftStickLeft: holdMapping(KeyCodeMapping.keyJ),
+				.leftStickDown: holdMapping(KeyCodeMapping.keyK),
+				.leftStickRight: holdMapping(KeyCodeMapping.keyL)
+			]
+
+			var profile = Profile(name: "Custom IJKL Movement", buttonMappings: mappings)
+			profile.joystickSettings.leftStickMode = .custom
+			profile.joystickSettings.leftStickCustomDeadzone = 0.1
+			installActiveProfile(profile)
+			controllerService.isConnected = true
+		}
+		await waitForTasks(0.12)
+
+		await MainActor.run {
+			controllerService.setLeftStickForTesting(CGPoint(x: 0.9, y: 0.9))
+		}
+		await waitForTasks(0.2)
+
+		XCTAssertEqual(startHoldCount(for: KeyCodeMapping.keyI), 1, "Diagonal up-right should press the custom Up key")
+		XCTAssertEqual(startHoldCount(for: KeyCodeMapping.keyL), 1, "Diagonal up-right should press the custom Right key")
+		XCTAssertEqual(startHoldCount(for: KeyCodeMapping.keyJ), 0, "Diagonal up-right should not press Left")
+		XCTAssertEqual(startHoldCount(for: KeyCodeMapping.keyK), 0, "Diagonal up-right should not press Down")
+		let upIsActive = await isActiveButton(.leftStickUp)
+		let rightIsActive = await isActiveButton(.leftStickRight)
+		XCTAssertTrue(upIsActive)
+		XCTAssertTrue(rightIsActive)
+	}
+
 	func testCustomDirectionScrollRepeatsWhileStickHeldAndStopsAtCenter() async throws {
 		await MainActor.run {
 			var profile = Profile(name: "Custom Scroll Direction", buttonMappings: [

--- a/XboxControllerMapper/XboxControllerMapperTests/JoystickCustomDirectionMappingTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/JoystickCustomDirectionMappingTests.swift
@@ -265,6 +265,98 @@ final class JoystickCustomDirectionMappingTests: XCTestCase {
 		XCTAssertTrue(rightIsActive)
 	}
 
+	func testCustomDirectionScrollRepeatsWhileStickHeldAndStopsAtCenter() async throws {
+		await MainActor.run {
+			var profile = Profile(name: "Custom Scroll Direction", buttonMappings: [
+				.leftStickUp: KeyMapping(keyCode: KeyCodeMapping.scrollUp),
+				.leftStickLeft: KeyMapping(keyCode: KeyCodeMapping.scrollLeft)
+			])
+			profile.joystickSettings.leftStickMode = .custom
+			profile.joystickSettings.leftStickCustomDeadzone = 0.1
+			profile.joystickSettings.scrollAcceleration = 0
+			installActiveProfile(profile)
+			controllerService.isConnected = true
+		}
+		await waitForTasks(0.12)
+
+		mockInputSimulator.clearEvents()
+		await MainActor.run {
+			controllerService.setLeftStickForTesting(CGPoint(x: 0, y: 0.9))
+		}
+		await waitForTasks(0.2)
+
+		let verticalScrolls = scrollEvents().filter { $0.dy > 0 && $0.dx == 0 }
+		XCTAssertGreaterThanOrEqual(verticalScrolls.count, 2, "Holding a custom Scroll Up direction should emit continuously")
+
+		mockInputSimulator.clearEvents()
+		await MainActor.run {
+			controllerService.setLeftStickForTesting(CGPoint(x: -0.9, y: 0))
+		}
+		await waitForTasks(0.2)
+
+		let horizontalScrolls = scrollEvents().filter { $0.dx > 0 && $0.dy == 0 }
+		XCTAssertGreaterThanOrEqual(horizontalScrolls.count, 2, "Holding a custom Scroll Left direction should emit continuously")
+
+		mockInputSimulator.clearEvents()
+		await MainActor.run {
+			controllerService.setLeftStickForTesting(.zero)
+		}
+		await waitForTasks(0.08)
+		mockInputSimulator.clearEvents()
+		await waitForTasks(0.18)
+
+		XCTAssertEqual(scrollEvents().count, 0, "Centering the stick should stop custom direction scrolling")
+	}
+
+	func testCustomDirectionScrollUsesScrollSensitivity() async throws {
+		await MainActor.run {
+			var lowSensitivityProfile = Profile(name: "Low Scroll Sensitivity", buttonMappings: [
+				.leftStickUp: KeyMapping(keyCode: KeyCodeMapping.scrollUp)
+			])
+			lowSensitivityProfile.joystickSettings.leftStickMode = .custom
+			lowSensitivityProfile.joystickSettings.leftStickCustomDeadzone = 0.1
+			lowSensitivityProfile.joystickSettings.scrollSensitivity = 0
+			lowSensitivityProfile.joystickSettings.scrollAcceleration = 0
+			installActiveProfile(lowSensitivityProfile)
+			controllerService.isConnected = true
+		}
+		await waitForTasks(0.12)
+
+		mockInputSimulator.clearEvents()
+		await MainActor.run {
+			controllerService.setLeftStickForTesting(CGPoint(x: 0, y: 0.9))
+		}
+		await waitForTasks(0.16)
+		let lowMax = scrollEvents().map(\.dy).max() ?? 0
+
+		await MainActor.run {
+			controllerService.setLeftStickForTesting(.zero)
+		}
+		await waitForTasks(0.12)
+
+		await MainActor.run {
+			var highSensitivityProfile = Profile(name: "High Scroll Sensitivity", buttonMappings: [
+				.leftStickUp: KeyMapping(keyCode: KeyCodeMapping.scrollUp)
+			])
+			highSensitivityProfile.joystickSettings.leftStickMode = .custom
+			highSensitivityProfile.joystickSettings.leftStickCustomDeadzone = 0.1
+			highSensitivityProfile.joystickSettings.scrollSensitivity = 1
+			highSensitivityProfile.joystickSettings.scrollAcceleration = 0
+			installActiveProfile(highSensitivityProfile)
+		}
+		await waitForTasks(0.12)
+
+		mockInputSimulator.clearEvents()
+		await MainActor.run {
+			controllerService.setLeftStickForTesting(CGPoint(x: 0, y: 0.9))
+		}
+		await waitForTasks(0.16)
+		let highMax = scrollEvents().map(\.dy).max() ?? 0
+
+		XCTAssertGreaterThan(lowMax, 0, "Low sensitivity should still produce scroll output")
+		XCTAssertGreaterThan(highMax, lowMax * 10, "Custom direction scrolling should respect scroll sensitivity")
+	}
+
     func testCustomLeftStickDirectionCanCompleteChord() async throws {
         await MainActor.run {
             controllerService.chordWindow = 0.2
@@ -621,6 +713,15 @@ final class JoystickCustomDirectionMappingTests: XCTestCase {
             }
             return false
         }.count
+    }
+
+    private func scrollEvents() -> [(dx: CGFloat, dy: CGFloat)] {
+        mockInputSimulator.events.compactMap {
+            if case .scroll(let dx, let dy) = $0 {
+                return (dx, dy)
+            }
+            return nil
+        }
     }
 
     private func firstStartHoldIndex(for keyCode: CGKeyCode, in events: [MockInputSimulator.Event]) -> Int? {

--- a/XboxControllerMapper/XboxControllerMapperTests/KeyCodeMappingDisplayTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/KeyCodeMappingDisplayTests.swift
@@ -14,6 +14,10 @@ final class KeyCodeMappingDisplayTests: XCTestCase {
         XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.mouseLeftClick), "Left Click")
         XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.scrollUp), "Scroll Up")
         XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.scrollDown), "Scroll Down")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.scrollLeft), "Scroll Left")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.scrollRight), "Scroll Right")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.mouseBackClick), "Back Button")
+        XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.mouseForwardClick), "Forward Button")
         XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.mediaPlayPause), "Play/Pause")
         XCTAssertEqual(KeyCodeMapping.displayName(for: KeyCodeMapping.brightnessDown), "Brightness Down")
     }
@@ -30,6 +34,10 @@ final class KeyCodeMappingDisplayTests: XCTestCase {
         XCTAssertTrue(options.contains(where: { $0.name == "On-Screen Keyboard" }))
         XCTAssertTrue(options.contains(where: { $0.name == "Scroll Up" }))
         XCTAssertTrue(options.contains(where: { $0.name == "Scroll Down" }))
+        XCTAssertTrue(options.contains(where: { $0.name == "Scroll Left" }))
+        XCTAssertTrue(options.contains(where: { $0.name == "Scroll Right" }))
+        XCTAssertTrue(options.contains(where: { $0.name == "Back Button" }))
+        XCTAssertTrue(options.contains(where: { $0.name == "Forward Button" }))
 
         for option in options {
             XCTAssertFalse(option.name.isEmpty)
@@ -84,14 +92,19 @@ final class KeyCodeMappingDisplayTests: XCTestCase {
         XCTAssertNotEqual(KeyCodeMapping.scrollUp, KeyCodeMapping.mouseLeftClick)
         XCTAssertNotEqual(KeyCodeMapping.scrollUp, KeyCodeMapping.mouseRightClick)
         XCTAssertNotEqual(KeyCodeMapping.scrollUp, KeyCodeMapping.mouseMiddleClick)
+        XCTAssertNotEqual(KeyCodeMapping.scrollLeft, KeyCodeMapping.mouseBackClick)
+        XCTAssertNotEqual(KeyCodeMapping.scrollRight, KeyCodeMapping.mouseForwardClick)
         XCTAssertNotEqual(KeyCodeMapping.scrollDown, KeyCodeMapping.mouseLeftClick)
         XCTAssertNotEqual(KeyCodeMapping.scrollDown, KeyCodeMapping.mouseRightClick)
         XCTAssertNotEqual(KeyCodeMapping.scrollDown, KeyCodeMapping.mouseMiddleClick)
         XCTAssertNotEqual(KeyCodeMapping.scrollUp, KeyCodeMapping.scrollDown)
+        XCTAssertNotEqual(KeyCodeMapping.scrollLeft, KeyCodeMapping.scrollRight)
 
         // Scroll actions should not be classified as mouse buttons
         XCTAssertFalse(KeyCodeMapping.isMouseButton(KeyCodeMapping.scrollUp))
         XCTAssertFalse(KeyCodeMapping.isMouseButton(KeyCodeMapping.scrollDown))
+        XCTAssertFalse(KeyCodeMapping.isMouseButton(KeyCodeMapping.scrollLeft))
+        XCTAssertFalse(KeyCodeMapping.isMouseButton(KeyCodeMapping.scrollRight))
     }
 
     func testDisplayName_DistinguishesLeftAndRightModifiers() {
@@ -150,10 +163,14 @@ final class KeyCodeMappingDisplayTests: XCTestCase {
         XCTAssertTrue(KeyCodeMapping.isMouseButton(KeyCodeMapping.mouseLeftClick))
         XCTAssertTrue(KeyCodeMapping.isMouseButton(KeyCodeMapping.mouseRightClick))
         XCTAssertTrue(KeyCodeMapping.isMouseButton(KeyCodeMapping.mouseMiddleClick))
+        XCTAssertTrue(KeyCodeMapping.isMouseButton(KeyCodeMapping.mouseBackClick))
+        XCTAssertTrue(KeyCodeMapping.isMouseButton(KeyCodeMapping.mouseForwardClick))
         XCTAssertFalse(KeyCodeMapping.isMouseButton(KeyCodeMapping.keyA))
 
         XCTAssertTrue(KeyCodeMapping.isScrollAction(KeyCodeMapping.scrollUp))
         XCTAssertTrue(KeyCodeMapping.isScrollAction(KeyCodeMapping.scrollDown))
+        XCTAssertTrue(KeyCodeMapping.isScrollAction(KeyCodeMapping.scrollLeft))
+        XCTAssertTrue(KeyCodeMapping.isScrollAction(KeyCodeMapping.scrollRight))
         XCTAssertFalse(KeyCodeMapping.isScrollAction(KeyCodeMapping.mouseLeftClick))
         XCTAssertFalse(KeyCodeMapping.isScrollAction(KeyCodeMapping.keyA))
 
@@ -168,8 +185,21 @@ final class KeyCodeMappingDisplayTests: XCTestCase {
         XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.mouseLeftClick))
         XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.scrollUp))
         XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.scrollDown))
+        XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.scrollLeft))
+        XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.scrollRight))
+        XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.mouseBackClick))
+        XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.mouseForwardClick))
         XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.showOnScreenKeyboard))
         XCTAssertTrue(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.mediaNext))
         XCTAssertFalse(KeyCodeMapping.isSpecialMarker(KeyCodeMapping.keyA))
+    }
+
+    func testScrollDelta_ForDiscreteScrollActions() {
+        XCTAssertEqual(KeyCodeMapping.scrollDelta(for: KeyCodeMapping.scrollUp, amount: 10).dy, 10)
+        XCTAssertEqual(KeyCodeMapping.scrollDelta(for: KeyCodeMapping.scrollDown, amount: 10).dy, -10)
+        XCTAssertEqual(KeyCodeMapping.scrollDelta(for: KeyCodeMapping.scrollLeft, amount: 10).dx, 10)
+        XCTAssertEqual(KeyCodeMapping.scrollDelta(for: KeyCodeMapping.scrollRight, amount: 10).dx, -10)
+        XCTAssertEqual(KeyCodeMapping.scrollDelta(for: KeyCodeMapping.keyA, amount: 10).dx, 0)
+        XCTAssertEqual(KeyCodeMapping.scrollDelta(for: KeyCodeMapping.keyA, amount: 10).dy, 0)
     }
 }

--- a/XboxControllerMapper/XboxControllerMapperTests/MappingEngineLayerAndLifecycleTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/MappingEngineLayerAndLifecycleTests.swift
@@ -1144,4 +1144,37 @@ final class MappingEngineLayerAndLifecycleTests: XCTestCase {
         }.count
         XCTAssertEqual(homeKeyCount, 0, "Source profile mapping should not execute while controller input is routed to remote")
     }
+
+    func testLocalControllerButton_executesImmediatelyAfterUnconfirmedRemoteSessionCancels() async throws {
+        await MainActor.run {
+            installActiveProfile(Profile(name: "Home After Cancel", buttonMappings: [.a: .key(10)]))
+            mockInputSimulator.clearEvents()
+        }
+
+        let zone = UniversalControlMouseRelay.HandoffZone(
+            localDisplayID: nil,
+            localEdge: .right,
+            localRangeMin: nil,
+            localRangeMax: nil,
+            remoteHost: "127.0.0.1",
+            remotePort: 65530,
+            remoteEntryEdge: .left,
+            remoteReturnEdge: .left
+        )
+        UniversalControlMouseRelay.shared.beginRemoteSession(zone: zone)
+        UniversalControlMouseRelay.shared.cancelUnconfirmedRemoteSession()
+        defer { UniversalControlMouseRelay.shared.setRemoteSessionActive(false) }
+
+        await MainActor.run {
+            controllerService.buttonPressed(.a)
+            controllerService.buttonReleased(.a)
+        }
+        await waitForTasks()
+
+        let homeKeyCount = mockInputSimulator.events.filter {
+            if case .pressKey(let keyCode, _) = $0 { return keyCode == 10 }
+            return false
+        }.count
+        XCTAssertEqual(homeKeyCount, 1, "Canceling an unconfirmed handoff should immediately restore local controller routing")
+    }
 }

--- a/XboxControllerMapper/XboxControllerMapperTests/ModifierFlagsSideTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/ModifierFlagsSideTests.swift
@@ -226,14 +226,7 @@ private final class RecordingInputSimulator: InputSimulatorProtocol, @unchecked 
     func moveMouseNative(dx: Int, dy: Int) {}
     func warpMouseTo(point: CGPoint) {}
     var isLeftMouseButtonHeld: Bool { false }
-    func scroll(
-		dx: CGFloat,
-		dy: CGFloat,
-		phase: CGScrollPhase?,
-		momentumPhase: CGMomentumScrollPhase?,
-		isContinuous: Bool,
-		flags: CGEventFlags
-    ) {}
+    func scroll(event: ScrollEvent) {}
     func executeMapping(_ mapping: KeyMapping) {}
     func startHoldMapping(_ mapping: KeyMapping) {}
     func stopHoldMapping(_ mapping: KeyMapping) {}


### PR DESCRIPTION
## Summary
- add individual Scroll Up/Down/Left/Right key actions and mouse Back/Forward actions
- add a Show Mouse visual picker alongside Show Keyboard in the mapping editor
- make custom joystick direction scroll actions repeat while held, with existing sensitivity/acceleration
- keep source controller input from falling back locally during a failed Universal Control handoff window

Closes #43

## Verification
- git -c core.whitespace=trailing-space,cr-at-eol diff --check
- xcodebuild test -project XboxControllerMapper/XboxControllerMapper.xcodeproj -scheme XboxControllerMapper -derivedDataPath build/test-issue-43-focused -destination 'platform=macOS' -only-testing:XboxControllerMapperTests/JoystickCustomDirectionMappingTests -only-testing:XboxControllerMapperTests/KeyCodeMappingDisplayTests -only-testing:XboxControllerMapperTests/MappingEngineLayerAndLifecycleTests/testLocalControllerButton_doesNotExecuteHomeMappingDuringRemoteSession\n- make test-full\n- make build BUILD_FROM_SOURCE=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Horizontal scrolling (left/right) and back/forward mouse button support
  * Scroll actions now honor modifier keys and produce directional deltas
  * Joystick custom directions emit continuous, joystick-driven scroll while held
  * New visual mouse-button picker and updated mapping editor/sheet UI
  * Remote controller input routing includes a short post-handshake grace window

* **Tests**
  * Added tests for joystick scrolling, diagonal custom directions, and modifier behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->