### PR TITLE
🎨 Palette: Add missing tooltips to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,6 +8,6 @@
 ## 2026-06-06 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
 **Learning:** In macOS SwiftUI applications, icon-only buttons often have either `.help()` (for hover tooltips) or `.accessibilityLabel()` (for VoiceOver), but frequently lack both. Both are necessary because they serve different user interaction models—`.help` for visual hover feedback and `.accessibilityLabel` for screen readers.
 **Action:** When adding or reviewing icon-only buttons in SwiftUI, always ensure symmetry by defining both `.help("Description")` and `.accessibilityLabel("Description")` to cover all accessibility and usability vectors.
-## $(date +%Y-%m-%d) - Found instances lacking symmetric accessibility labels
+## 2026-06-09 - Found instances lacking symmetric accessibility labels
 **Learning:** Found two icon-only buttons ("Add profile" in `ProfileSidebarViews.swift` and "Settings" in `ContentToolbar.swift`) that only had `.accessibilityLabel()` but lacked `.help()` for hover tooltips.
 **Action:** Always ensure symmetry in accessibility modifiers on SwiftUI icon buttons by pairing `.accessibilityLabel()` with `.help()`.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,6 @@
 ## 2026-06-06 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
 **Learning:** In macOS SwiftUI applications, icon-only buttons often have either `.help()` (for hover tooltips) or `.accessibilityLabel()` (for VoiceOver), but frequently lack both. Both are necessary because they serve different user interaction models—`.help` for visual hover feedback and `.accessibilityLabel` for screen readers.
 **Action:** When adding or reviewing icon-only buttons in SwiftUI, always ensure symmetry by defining both `.help("Description")` and `.accessibilityLabel("Description")` to cover all accessibility and usability vectors.
+## $(date +%Y-%m-%d) - Found instances lacking symmetric accessibility labels
+**Learning:** Found two icon-only buttons ("Add profile" in `ProfileSidebarViews.swift` and "Settings" in `ContentToolbar.swift`) that only had `.accessibilityLabel()` but lacked `.help()` for hover tooltips.
+**Action:** Always ensure symmetry in accessibility modifiers on SwiftUI icon buttons by pairing `.accessibilityLabel()` with `.help()`.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentToolbar.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentToolbar.swift
@@ -44,6 +44,7 @@ struct ContentToolbar: View {
             .buttonStyle(.plain)
             .hoverableIconButton()
             .accessibilityLabel("Settings")
+            .help("Settings")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ProfileSidebarViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ProfileSidebarViews.swift
@@ -73,6 +73,7 @@ struct ProfileSidebar: View {
                 }
                 .menuStyle(.borderlessButton)
                 .accessibilityLabel("Add profile")
+                .help("Add profile")
                 .fixedSize()
                 .hoverableIconButton()
             }


### PR DESCRIPTION
💡 **What**: Added `.help("Settings")` and `.help("Add profile")` to their respective icon-only buttons.
🎯 **Why**: While screen readers could read `.accessibilityLabel()`, sighted mouse users on macOS had no tooltip hint for these critical icon buttons.
♿ **Accessibility**: Enhanced visual hover discoverability for macOS users while maintaining existing VoiceOver support.

---
*PR created automatically by Jules for task [7678132752822010327](https://jules.google.com/task/7678132752822010327) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility**
  * Added hover help tooltips to icon-only buttons on macOS (Settings and Add Profile) to improve discoverability alongside existing accessibility labels.
* **Documentation**
  * Added a dated note reminding to pair accessibility labels with help/tooltips for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->