### PR TITLE
🎨 Palette: Add missing tooltips to list action buttons

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -115,6 +115,7 @@ struct ChordRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
+                .help("Edit")
                 .accessibilityLabel("Edit")
 
                 Button(action: onDelete) {
@@ -122,6 +123,7 @@ struct ChordRow: View {
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
+                .help("Delete")
                 .accessibilityLabel("Delete")
             }
         }
@@ -259,6 +261,7 @@ struct SequenceRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
+                .help("Edit")
                 .accessibilityLabel("Edit")
 
                 Button(action: onDelete) {
@@ -266,6 +269,7 @@ struct SequenceRow: View {
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
+                .help("Delete")
                 .accessibilityLabel("Delete")
             }
         }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/GestureListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/GestureListViews.swift
@@ -78,6 +78,7 @@ struct GestureRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
+                .help("Edit")
                 .accessibilityLabel("Edit")
 
                 if mapping?.hasAction == true {
@@ -86,6 +87,7 @@ struct GestureRow: View {
                             .foregroundColor(.red.opacity(0.8))
                     }
                     .buttonStyle(.borderless)
+                    .help("Clear")
                     .accessibilityLabel("Clear")
                 }
             }


### PR DESCRIPTION
💡 **What:** Added `.help("...")` tooltips to the icon-only action buttons (Edit, Delete, Clear) in list rows for Gestures, Chords, and Sequences.
🎯 **Why:** To make the interface more intuitive and resolve the ambiguity of relying solely on iconography. This follows the accessibility standards of having both a visual tooltip (via `.help`) and VoiceOver text (via `.accessibilityLabel`).
♿ **Accessibility:** Ensures sighted mouse users have the same contextual information that was previously only available to VoiceOver users.

---
*PR created automatically by Jules for task [10026388861524157399](https://jules.google.com/task/10026388861524157399) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added helpful tooltips to action buttons (Edit, Delete, and Clear) across the interface for improved accessibility and button discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->