### PR TITLE
🎨 Palette: Add accessibility and tooltips to webhook header buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -8,3 +8,7 @@
 ## 2026-06-06 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
 **Learning:** In macOS SwiftUI applications, icon-only buttons often have either `.help()` (for hover tooltips) or `.accessibilityLabel()` (for VoiceOver), but frequently lack both. Both are necessary because they serve different user interaction models—`.help` for visual hover feedback and `.accessibilityLabel` for screen readers.
 **Action:** When adding or reviewing icon-only buttons in SwiftUI, always ensure symmetry by defining both `.help("Description")` and `.accessibilityLabel("Description")` to cover all accessibility and usability vectors.
+
+## 2024-05-19 - [Missing Accessibility on Dynamic Form Dictionary Buttons]
+**Learning:** Icon-only buttons used for adding/removing items in dynamic dictionary forms (e.g., webhook headers with `plus.circle.fill` and `minus.circle.fill`) are frequent vectors for missing accessibility labels and tooltips, because they are often implemented with plain button styles without considering screen reader context.
+**Action:** Always verify that inline addition/removal buttons in repeated form elements have explicit `.help()` and `.accessibilityLabel()` modifiers attached to them to ensure they can be understood and navigated accurately by all users.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ActionMappingEditor.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ActionMappingEditor.swift
@@ -380,6 +380,8 @@ struct ActionMappingEditor: View {
                                 .foregroundColor(.red)
                         }
                         .buttonStyle(.plain)
+                        .help("Remove header")
+                        .accessibilityLabel("Remove header")
                     }
                 }
 
@@ -401,6 +403,8 @@ struct ActionMappingEditor: View {
                             .foregroundColor(.green)
                     }
                     .buttonStyle(.plain)
+                    .help("Add header")
+                    .accessibilityLabel("Add header")
                     .disabled(state.newWebhookHeaderKey.isEmpty)
                 }
             }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordMappingSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordMappingSheet.swift
@@ -624,6 +624,8 @@ struct ChordMappingSheet: View, ControllerTypeProviding {
                                         .foregroundColor(.red)
                                 }
                                 .buttonStyle(.plain)
+                                .help("Remove header")
+                                .accessibilityLabel("Remove header")
                             }
                         }
 
@@ -645,6 +647,8 @@ struct ChordMappingSheet: View, ControllerTypeProviding {
                                     .foregroundColor(.green)
                             }
                             .buttonStyle(.plain)
+                            .help("Add header")
+                            .accessibilityLabel("Add header")
                             .disabled(newWebhookHeaderKey.isEmpty)
                         }
                     }


### PR DESCRIPTION
### 💡 What
Added `.help()` tooltips and `.accessibilityLabel()` modifiers to the icon-only `plus.circle.fill` and `minus.circle.fill` buttons in the Webhook Headers section of `ActionMappingEditor.swift` and `ChordMappingSheet.swift`. 

### 🎯 Why
Icon-only buttons used for adding or removing items in a dictionary form were ambiguous to screen readers and lacked hover context for mouse users. This change ensures these interactive elements are clearly communicated to all users, making the dynamic form more accessible and intuitive.

### ♿ Accessibility
- Added `Remove header` label to minus buttons.
- Added `Add header` label to plus buttons.

Also updated `.Jules/palette.md` to document this learning about dynamic form lists.

---
*PR created automatically by Jules for task [1136719797351930065](https://jules.google.com/task/1136719797351930065) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added accessibility labels and tooltips to header add/remove buttons for improved screen reader support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->