### PR TITLE
🎨 Palette: Add missing accessibility labels and tooltips to icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -12,3 +12,6 @@
 ## 2024-05-19 - [Missing Accessibility on Dynamic Form Dictionary Buttons]
 **Learning:** Icon-only buttons used for adding/removing items in dynamic dictionary forms (e.g., webhook headers with `plus.circle.fill` and `minus.circle.fill`) are frequent vectors for missing accessibility labels and tooltips, because they are often implemented with plain button styles without considering screen reader context.
 **Action:** Always verify that inline addition/removal buttons in repeated form elements have explicit `.help()` and `.accessibilityLabel()` modifiers attached to them to ensure they can be understood and navigated accurately by all users.
+## 2024-05-14 - [Icon Button Accessibility Gap]
+**Learning:** In standard SwiftUI development for macOS, icon-only buttons (`Image(systemName: ...)`) are frequently missing `.help()` (for hover tooltips) and `.accessibilityLabel()` (for VoiceOver). Several core navigation components (like Layer tabs and Sidebar buttons) suffered from this pattern.
+**Action:** Always verify that every `Button` wrapping an `Image` has both `.help()` and `.accessibilityLabel()` strings defined, unless explicitly marked as decorative.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Components/StreamOverlayView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Components/StreamOverlayView.swift
@@ -71,6 +71,7 @@ struct StreamOverlayView: View {
                 .buttonStyle(.plain)
                 .padding(5)
                 .help("Close stream overlay")
+                .accessibilityLabel("Close stream overlay")
             }
         }
         .onHover { isHoveringPanel = $0 }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentToolbar.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentToolbar.swift
@@ -43,6 +43,7 @@ struct ContentToolbar: View {
             }
             .buttonStyle(.plain)
             .hoverableIconButton()
+            .help("Settings")
             .accessibilityLabel("Settings")
         }
         .padding(.horizontal, 16)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LayerTabBar.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LayerTabBar.swift
@@ -143,6 +143,8 @@ struct LayerTabBar: View {
                     .cornerRadius(6)
                 }
                 .buttonStyle(.plain)
+                .help("Add Layer")
+                .accessibilityLabel("Add Layer")
                 .foregroundColor(.secondary)
                 .hoverableButton()
             }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ProfileSidebarViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ProfileSidebarViews.swift
@@ -72,6 +72,7 @@ struct ProfileSidebar: View {
                         .clipShape(Circle())
                 }
                 .menuStyle(.borderlessButton)
+                .help("Add profile")
                 .accessibilityLabel("Add profile")
                 .fixedSize()
                 .hoverableIconButton()


### PR DESCRIPTION
🎨 Palette: Icon Button Accessibility improvements

💡 What: Added missing `.help()` (hover tooltips) and `.accessibilityLabel()` (VoiceOver) to several icon-only buttons across the app interface (ContentToolbar, ProfileSidebarViews, LayerTabBar, and StreamOverlayView).
🎯 Why: Icon-only buttons without text equivalents are difficult for users relying on screen readers to understand, and lack discoverability for mouse users who expect hover text explaining the action.
♿ Accessibility: Improves VoiceOver navigation and general discoverability for the Settings, Add Profile, Close Stream Overlay, and Add Layer buttons.

---
*PR created automatically by Jules for task [7051295741052118531](https://jules.google.com/task/7051295741052118531) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added accessibility labels and hover tooltips to icon-only buttons throughout the app, improving support for VoiceOver and other assistive technologies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->