### PR TITLE
🎨 Palette: Ensure symmetry in accessibility and tooltips for icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -15,3 +15,7 @@
 ## 2024-05-14 - [Icon Button Accessibility Gap]
 **Learning:** In standard SwiftUI development for macOS, icon-only buttons (`Image(systemName: ...)`) are frequently missing `.help()` (for hover tooltips) and `.accessibilityLabel()` (for VoiceOver). Several core navigation components (like Layer tabs and Sidebar buttons) suffered from this pattern.
 **Action:** Always verify that every `Button` wrapping an `Image` has both `.help()` and `.accessibilityLabel()` strings defined, unless explicitly marked as decorative.
+
+## 2024-06-08 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
+**Learning:** Verified the necessity of ensuring full symmetry in accessibility and tooltips for icon-only buttons (`Image(systemName: ...)`). These buttons often get one but not the other (`.help()` without `.accessibilityLabel()`, or vice-versa), which causes poor UX for some group of users.
+**Action:** When adding or modifying icon buttons, always apply both `.help("Action")` and `.accessibilityLabel("Action")`.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingsTab.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingsTab.swift
@@ -535,6 +535,7 @@ struct ButtonMappingsTab: View {
                 }
                 .buttonStyle(.plain)
                 .help("Hide \(section.label)")
+                .accessibilityLabel("Hide \(section.label)")
                 .padding(.top, 6)
                 .padding(.trailing, 8)
             }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommunityProfilesSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommunityProfilesSheet.swift
@@ -648,6 +648,7 @@ private struct CodeBlockView: View {
             }
             .buttonStyle(.plain)
             .help(didCopy ? "Copied" : "Copy code")
+            .accessibilityLabel(didCopy ? "Copied" : "Copy code")
             .padding(4)
         }
     }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SequenceMappingSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SequenceMappingSheet.swift
@@ -168,6 +168,7 @@ struct SequenceMappingSheet: View, ControllerTypeProviding {
                                             .foregroundColor(.red.opacity(0.7))
                                     }
                                     .buttonStyle(.borderless)
+                                    .help("Remove step")
 										.accessibilityLabel("Remove \(button.displayName(forDualSense: isPlayStation, forNintendo: isNintendo, forAppleTVRemote: isAppleTVRemote)) from step \(index + 1)")
                                 }
                             }


### PR DESCRIPTION
💡 **What**: Added `.accessibilityLabel()` and `.help()` modifiers to several icon-only buttons across the app.
🎯 **Why**: Sighted users rely on tooltips (`.help`) to understand what an icon button does on hover, while screen reader users rely on VoiceOver to read out an `.accessibilityLabel`. To ensure an intuitive and accessible experience, both should always be symmetrical on icon-only buttons.
♿ **Accessibility**: Ensured full accessibility for the "Hide Section" button, the "Copy Code" button, and the "Remove Step" button.

---
*PR created automatically by Jules for task [15089943999790081312](https://jules.google.com/task/15089943999790081312) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidelines for ensuring consistent accessibility support across icon-only buttons in the interface.

* **Bug Fixes**
  * Improved accessibility descriptions for various buttons throughout the app, providing clearer labels for screen readers and better contextual help for all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->