### PR TITLE
🛡️ Sentinel: [HIGH] Fix Insecure URL Scheme Execution

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -2,3 +2,7 @@
 **Vulnerability:** The application was storing a sensitive shared secret (`universalControlRelaySharedSecret`) in plaintext within `UserDefaults`.
 **Learning:** Even when a secret is written to the secure Keychain, legacy fallback mechanisms or redundant storage can accidentally leave copies in insecure locations like `UserDefaults`, creating an information disclosure vulnerability on the device.
 **Prevention:** Avoid writing secrets to `UserDefaults`. Use secure Keychain access APIs exclusively for sensitive data. When migrating secrets from `UserDefaults` to the Keychain, always explicitly delete the old insecure copy immediately after migration.
+## 2026-06-15 - [Insecure URL Scheme Execution]
+**Vulnerability:** The app allowed opening any URL string without validating the scheme, making it possible for attackers to use NSWorkspace.shared.open with potentially dangerous handlers like file:// or system preference handlers.
+**Learning:** Passing untrusted URLs to NSWorkspace.shared.open or /usr/bin/open acts similarly to a shell execution if non-standard or local file schemes are used. It bypasses normal app boundaries.
+**Prevention:** Always restrict URL schemes to an explicit allowlist (like http, https) before delegating to system URL openers.

--- a/XboxControllerMapper/XboxControllerMapper/Services/UI/CommandWheelManager.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/UI/CommandWheelManager.swift
@@ -521,12 +521,14 @@ class CommandWheelManager: ObservableObject {
     private func openWebsite(url urlString: String) {
         let urlStr = Self.normalizeURL(urlString)
         guard let url = URL(string: urlStr) else { return }
+        guard let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme) else { return }
         NSWorkspace.shared.open(url)
         usageStatsService?.recordLinkOpened()
     }
 
     private func openWebsiteIncognito(url urlString: String) {
         let urlStr = Self.normalizeURL(urlString)
+        guard let url = URL(string: urlStr), let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme) else { return }
 
         // Determine the default browser
         let defaultBrowser = LSCopyDefaultHandlerForURLScheme("https" as CFString)?.takeRetainedValue() as String? ?? ""
@@ -567,9 +569,8 @@ class CommandWheelManager: ObservableObject {
             return
         default:
             // Fallback: just open normally if browser is unknown
-            if let url = URL(string: urlStr) {
-                NSWorkspace.shared.open(url)
-            }
+            // URL and scheme validation already performed at start of function
+            NSWorkspace.shared.open(url)
             return
         }
 

--- a/XboxControllerMapper/XboxControllerMapper/Services/UI/OnScreenKeyboardManager.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/UI/OnScreenKeyboardManager.swift
@@ -1395,6 +1395,12 @@ class OnScreenKeyboardManager: ObservableObject {
             return
         }
 
+        // Security: Only allow http/https schemes
+        guard let scheme = url.scheme?.lowercased(), ["http", "https"].contains(scheme) else {
+            NSLog("[OnScreenKeyboard] Blocked non-HTTP URL scheme: \(urlString)")
+            return
+        }
+
         NSWorkspace.shared.open(url)
         usageStatsService?.recordLinkOpened()
     }


### PR DESCRIPTION
This PR fixes a high-severity security vulnerability where user-provided URLs were being passed to `NSWorkspace.shared.open()` and `/usr/bin/open` without scheme validation. This could have allowed execution of arbitrary URL schemes like `file://`.

The fix adds strict scheme validation (allowing only `http` and `https`) to the relevant methods in `CommandWheelManager` and `OnScreenKeyboardManager`. I also recorded this learning in the Sentinel journal.

---
*PR created automatically by Jules for task [6905392468223346762](https://jules.google.com/task/6905392468223346762) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL validation to restrict URL opening to http and https schemes only. The app now prevents opening of unsupported or potentially unsafe URL schemes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->