### PR TITLE
🎨 Palette: Improve accessibility for icon-only buttons in TriggerKit

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -19,3 +19,6 @@
 ## 2024-06-08 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
 **Learning:** Verified the necessity of ensuring full symmetry in accessibility and tooltips for icon-only buttons (`Image(systemName: ...)`). These buttons often get one but not the other (`.help()` without `.accessibilityLabel()`, or vice-versa), which causes poor UX for some group of users.
 **Action:** When adding or modifying icon buttons, always apply both `.help("Action")` and `.accessibilityLabel("Action")`.
+## 2026-06-16 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
+**Learning:** Verified the necessity of ensuring full symmetry in accessibility and tooltips for icon-only buttons (`Image(systemName: ...)`). These buttons often get one but not the other (`.help()` without `.accessibilityLabel()`, or vice-versa), which causes poor UX for some group of users.
+**Action:** When adding or modifying icon buttons, always apply both `.help("Action")` and `.accessibilityLabel("Action")`.

--- a/TriggerKit/Sources/TriggerKitUI/AutomationMacroLibraryView.swift
+++ b/TriggerKit/Sources/TriggerKitUI/AutomationMacroLibraryView.swift
@@ -60,6 +60,7 @@ public struct AutomationMacroLibraryView: View {
 				}
 				.buttonStyle(.plain)
 				.help("New macro")
+				.accessibilityLabel("New macro")
 			}
 			.padding(.horizontal, 12)
 			.padding(.top, 12)
@@ -88,6 +89,7 @@ public struct AutomationMacroLibraryView: View {
 				}
 				.disabled(selectedID == nil)
 				.help("Duplicate")
+				.accessibilityLabel("Duplicate")
 
 				Button(role: .destructive) {
 					showDeleteConfirm = true
@@ -96,6 +98,7 @@ public struct AutomationMacroLibraryView: View {
 				}
 				.disabled(selectedID == nil)
 				.help("Delete")
+				.accessibilityLabel("Delete")
 			}
 			.buttonStyle(.plain)
 			.padding(.horizontal, 12)

--- a/TriggerKit/Sources/TriggerKitUI/AutomationProgramEditor.swift
+++ b/TriggerKit/Sources/TriggerKitUI/AutomationProgramEditor.swift
@@ -75,6 +75,7 @@ public struct AutomationProgramEditor: View {
 					}
 					.disabled(isTesting || program.steps.isEmpty)
 					.help("Run these steps now")
+					.accessibilityLabel("Run these steps now")
 				}
 
 				Menu {
@@ -191,6 +192,7 @@ public struct AutomationProgramEditor: View {
 				}
 				.disabled(!allowed)
 				.help(allowed ? (expanded ? "Collapse" : "Expand") : "Unavailable in this host")
+				.accessibilityLabel(allowed ? (expanded ? "Collapse" : "Expand") : "Unavailable in this host")
 
 				HStack(spacing: 8) {
 					Image(systemName: iconName(for: step))
@@ -216,6 +218,7 @@ public struct AutomationProgramEditor: View {
 				}
 				.disabled(index == 0)
 				.help("Move up")
+				.accessibilityLabel("Move up")
 
 				Button {
 					moveStep(from: index, by: 1)
@@ -224,6 +227,7 @@ public struct AutomationProgramEditor: View {
 				}
 				.disabled(index == program.steps.count - 1)
 				.help("Move down")
+				.accessibilityLabel("Move down")
 
 				Button(role: .destructive) {
 					deleteStep(at: index)
@@ -231,6 +235,7 @@ public struct AutomationProgramEditor: View {
 					Image(systemName: "trash")
 				}
 				.help("Delete")
+				.accessibilityLabel("Delete")
 			}
 			.buttonStyle(.plain)
 

--- a/TriggerKit/Sources/TriggerKitUI/ModifierSetEditor.swift
+++ b/TriggerKit/Sources/TriggerKitUI/ModifierSetEditor.swift
@@ -47,7 +47,8 @@ public struct ModifierSetEditor: View {
 		}
 		.buttonStyle(.plain)
 		.fixedSize(horizontal: true, vertical: false)
-		.help("Click to cycle Off, Any, Left, Right")
+		.help("\(label): Click to cycle Off, Any, Left, Right")
+		.accessibilityLabel("\(label): Click to cycle Off, Any, Left, Right")
 	}
 
 	private var functionButton: some View {


### PR DESCRIPTION
This change ensures symmetric usage of `.help()` and `.accessibilityLabel()` on all icon-only buttons in `AutomationMacroLibraryView`, `AutomationProgramEditor`, and `ModifierSetEditor`, improving the screen reader experience on macOS.

---
*PR created automatically by Jules for task [12489758692331309814](https://jules.google.com/task/12489758692331309814) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added descriptive accessibility labels to buttons throughout the application, including macro management, automation editing, and test controls
  * Enhanced modifier cycling controls with explicit help text describing behavior options
  * Improved assistive technology support across interface controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->