### PR TITLE
🛡️ Sentinel: [HIGH] Fix Sandbox Escape via URL Handler Scheme

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -6,3 +6,7 @@
 **Vulnerability:** The app allowed opening any URL string without validating the scheme, making it possible for attackers to use NSWorkspace.shared.open with potentially dangerous handlers like file:// or system preference handlers.
 **Learning:** Passing untrusted URLs to NSWorkspace.shared.open or /usr/bin/open acts similarly to a shell execution if non-standard or local file schemes are used. It bypasses normal app boundaries.
 **Prevention:** Always restrict URL schemes to an explicit allowlist (like http, https) before delegating to system URL openers.
+## 2026-06-16 - [Sandbox Escape via URL Handler Scheme]
+**Vulnerability:** Execution frameworks allowed untrusted automation configurations to open URLs with schemes like `file` and `x-apple.systempreferences`, effectively allowing arbitrary local execution or sandbox escapes via `NSWorkspace.shared.open`.
+**Learning:** `NSWorkspace.shared.open` delegates URL handling directly to the OS, executing system preferences panes or opening arbitrary files. Bounding allowed schemes is critical, and a strict blocklist is required when an allowlist is too restrictive for general automation.
+**Prevention:** Apply a strict blocklist for URL handlers (e.g. `file`, `x-apple.systempreferences`) at the core execution and validation levels when evaluating untrusted URL strings.

--- a/TriggerKit/Sources/TriggerKitCore/AutomationProgram+Validation.swift
+++ b/TriggerKit/Sources/TriggerKitCore/AutomationProgram+Validation.swift
@@ -207,6 +207,10 @@ private extension AutomationStep {
 		if let allowedSchemes, !allowedSchemes.contains(scheme) {
 			return [issue(disallowedCode, index: index, message: "\(label) scheme is not allowed: \(scheme)")]
 		}
+		let blockedSchemes: Set<String> = ["file", "x-apple.systempreferences"]
+		if blockedSchemes.contains(scheme) {
+			return [issue(disallowedCode, index: index, message: "\(label) scheme is blocked for security: \(scheme)")]
+		}
 		return []
 	}
 

--- a/TriggerKit/Sources/TriggerKitCore/AutomationProgram+Validation.swift
+++ b/TriggerKit/Sources/TriggerKitCore/AutomationProgram+Validation.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+
+public enum AutomationSecurityPolicy {
+	public static let blockedURLSchemes: Set<String> = ["file", "x-apple.systempreferences"]
+}
+
 public struct AutomationValidationPolicy: Equatable, Sendable {
 	public var allowsEmptyProgram: Bool
 	public var capabilities: AutomationCapabilities
@@ -207,8 +212,7 @@ private extension AutomationStep {
 		if let allowedSchemes, !allowedSchemes.contains(scheme) {
 			return [issue(disallowedCode, index: index, message: "\(label) scheme is not allowed: \(scheme)")]
 		}
-		let blockedSchemes: Set<String> = ["file", "x-apple.systempreferences"]
-		if blockedSchemes.contains(scheme) {
+		if AutomationSecurityPolicy.blockedURLSchemes.contains(scheme) {
 			return [issue(disallowedCode, index: index, message: "\(label) scheme is blocked for security: \(scheme)")]
 		}
 		return []

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -450,8 +450,7 @@ public final class AutomationExecutor {
 		if let allowedSchemes, !allowedSchemes.contains(scheme) {
 			return .failure("URL scheme not allowed: \(scheme)")
 		}
-		let blockedSchemes: Set<String> = ["file", "x-apple.systempreferences"]
-		if blockedSchemes.contains(scheme) {
+		if AutomationSecurityPolicy.blockedURLSchemes.contains(scheme) {
 			return .failure("URL scheme blocked for security: \(scheme)")
 		}
 		guard NSWorkspace.shared.open(url) else {

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -450,6 +450,10 @@ public final class AutomationExecutor {
 		if let allowedSchemes, !allowedSchemes.contains(scheme) {
 			return .failure("URL scheme not allowed: \(scheme)")
 		}
+		let blockedSchemes: Set<String> = ["file", "x-apple.systempreferences"]
+		if blockedSchemes.contains(scheme) {
+			return .failure("URL scheme blocked for security: \(scheme)")
+		}
 		guard NSWorkspace.shared.open(url) else {
 			return .failure("Could not open URL: \(urlString)")
 		}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Sandbox Escape via URL Handler Scheme

🚨 Severity: HIGH
💡 Vulnerability: Execution frameworks allowed untrusted automation configurations to open URLs with schemes like `file` and `x-apple.systempreferences`, effectively allowing arbitrary local execution or sandbox escapes via `NSWorkspace.shared.open`.
🎯 Impact: Attackers could use automation steps to execute local files or open system settings maliciously.
🔧 Fix: Added a strict blocklist for URL handlers (e.g. `file`, `x-apple.systempreferences`) at the core execution and validation levels when evaluating untrusted URL strings in `TriggerKit`.
✅ Verification: Statically verified the code changes to ensure the blocklist properly prevents `file` and `x-apple.systempreferences` execution.

---
*PR created automatically by Jules for task [1944738734155530959](https://jules.google.com/task/1944738734155530959) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened automation URL handling by blocking dangerous URL schemes (including `file://` and system preference schemes) before any external opening occurs.
  * Added clear validation feedback when a disallowed URL scheme is detected, reducing the risk of sandbox escape via URL handler schemes.
* **Documentation**
  * Updated the security sentinel record for 2026-06-16 to reflect the vulnerability and the implemented mitigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->