### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure plaintext storage fallback for OBS passwords

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -14,3 +14,7 @@
 **Vulnerability:** Execution frameworks allowed untrusted automation configurations to open URLs with schemes like `shortcuts`, `terminal`, `ssh`, `telnet`, `vnc`, `ftp`, `smb`, `afp`, effectively allowing arbitrary local execution or sandbox escapes via `NSWorkspace.shared.open`.
 **Learning:** Adding `file` and `x-apple.systempreferences` is not enough. Other local OS handlers (like `shortcuts://` or `terminal://`) can still perform actions directly from untrusted inputs without validation, acting as potential attack vectors.
 **Prevention:** Apply a comprehensive blocklist for URL handlers containing all potentially dangerous schemes (e.g. `shortcuts`, `terminal`, `ssh`, `telnet`, `vnc`, `ftp`, `smb`, `afp`) at the core execution and validation levels when evaluating untrusted URL strings.
+## 2026-06-22 - [Insecure Plaintext Fallback Storage]
+**Vulnerability:** The application was falling back to storing OBS passwords as plaintext strings inside exported/saved JSON models (`Macro.swift` and `SystemCommand.swift`) if saving to the macOS Keychain failed.
+**Learning:** Saving secrets to unencrypted formats simply because secure storage fails is a critical anti-pattern known as "failing open" that results in data exposure.
+**Prevention:** Always fail securely. If secure storage operations fail, discard the sensitive credential in memory rather than writing it insecurely to disk, even if it requires the user to re-authenticate later.

--- a/XboxControllerMapper/XboxControllerMapper/Models/Macros/Macro.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Models/Macros/Macro.swift
@@ -245,9 +245,8 @@ enum MacroStep: Codable, Equatable {
                 if KeychainService.storePassword(password, key: key) != nil {
                     try container.encode(key, forKey: .password)
                 } else {
-                    // Keychain store failed — fall back to plaintext to avoid silent data loss
-                    NSLog("[Macro] Keychain store failed, falling back to plaintext for OBS password")
-                    try container.encode(password, forKey: .password)
+                    // Keychain store failed — fail securely, do not write plaintext to disk
+                    NSLog("[Macro] Keychain store failed, discarding OBS password for security")
                 }
             }
             try container.encode(requestType, forKey: .requestType)

--- a/XboxControllerMapper/XboxControllerMapper/Models/SystemCommand.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Models/SystemCommand.swift
@@ -270,9 +270,8 @@ extension SystemCommand: Codable {
                 if KeychainService.storePassword(password, key: key) != nil {
                     try container.encode(key, forKey: .password)
                 } else {
-                    // Keychain store failed — fall back to plaintext to avoid silent data loss
-                    NSLog("[SystemCommand] Keychain store failed, falling back to plaintext for OBS password")
-                    try container.encode(password, forKey: .password)
+                    // Keychain store failed — fail securely, do not write plaintext to disk
+                    NSLog("[SystemCommand] Keychain store failed, discarding OBS password for security")
                 }
             }
             try container.encode(requestType, forKey: .requestType)


### PR DESCRIPTION
🚨 **Severity**: CRITICAL

💡 **Vulnerability**: The application was failing open by intentionally storing OBS WebSocket passwords in plaintext inside saved JSON structures (`SystemCommand.swift` and `Macro.swift`) if the secure Keychain storage operation failed. 

🎯 **Impact**: If Keychain access failed due to permissions or environment issues, users' OBS passwords would be silently written to disk as plaintext inside exported profiles or internal configuration files, leading to sensitive credential disclosure.

🔧 **Fix**: Updated `OBSWebSocketPayload` encoding in both `Macro.swift` and `SystemCommand.swift` to fail securely. If `KeychainService.storePassword` fails, the application now logs an error and safely discards the password instead of falling back to encoding it in plaintext.

✅ **Verification**: Static analysis verified `falling back to plaintext` no longer exists anywhere in the codebase. Testing environment limitations prevented unit test execution natively, but the logic removal eliminates the insecure write path.

---
*PR created automatically by Jules for task [4635798464128746884](https://jules.google.com/task/4635798464128746884) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a security vulnerability where OBS passwords could be stored in plaintext to disk when credential storage fails. The app now safely discards sensitive credentials instead of persisting them, enhancing protection against unauthorized access if configuration files are exported or accessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->