### PR TITLE
🎨 Palette: Improve accessibility for buttons with tooltips

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -22,3 +22,6 @@
 ## 2026-06-16 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
 **Learning:** Verified the necessity of ensuring full symmetry in accessibility and tooltips for icon-only buttons (`Image(systemName: ...)`). These buttons often get one but not the other (`.help()` without `.accessibilityLabel()`, or vice-versa), which causes poor UX for some group of users.
 **Action:** When adding or modifying icon buttons, always apply both `.help("Action")` and `.accessibilityLabel("Action")`.
+## 2026-06-23 - [SwiftUI Button Accessibility]
+**Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
+**Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ButtonMappingSheet.swift
@@ -899,6 +899,7 @@ struct ButtonMappingSheet: View {
                 .foregroundColor(.red)
                 .disabled(!canClearMapping)
                 .help(canClearMapping ? "Clear this button mapping" : "No mapping to clear")
+                .accessibilityLabel(canClearMapping ? "Clear this button mapping" : "No mapping to clear")
 
                 Spacer()
 

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
@@ -96,6 +96,7 @@ struct CommandWheelSettingsView: View {
                 }
                 .disabled(actions.count >= maxItems)
                 .help(actions.count >= maxItems ? "Maximum \(maxItems) actions" : "")
+                .accessibilityLabel("Add Action" + (actions.count >= maxItems ? ", maximum \(maxItems) actions reached" : ""))
             } header: {
                 HStack {
                     Text("Actions")

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentToolbar.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ContentToolbar.swift
@@ -79,6 +79,7 @@ struct ContentToolbar: View {
                 }
                 .buttonStyle(.plain)
                 .help("Free trial: \(days) day\(days == 1 ? "" : "s") left — click for license options")
+                .accessibilityLabel("Free trial: \(days) day\(days == 1 ? "" : "s") left")
             }
 
             // Enable/disable toggle

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/JoystickCustomDirectionPanel.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/JoystickCustomDirectionPanel.swift
@@ -110,6 +110,7 @@ struct JoystickCustomDirectionPanel: View {
             }
             .menuStyle(.borderlessButton)
             .help("Set all four custom stick directions")
+            .accessibilityLabel("Set all four custom stick directions")
         }
     }
 }


### PR DESCRIPTION
💡 What: Added `.accessibilityLabel` to several buttons and interactive elements that previously only had `.help` tooltips.
🎯 Why: Ensures that screen reader users (like VoiceOver) receive the same descriptive information as visual users hovering over elements. This improves overall accessibility for the app.
♿ Accessibility:
- Free trial button in `ContentToolbar.swift`
- "Clear Mapping" button in `ButtonMappingSheet.swift`
- "Add Action" button in `CommandWheelSettingsView.swift`
- Direction preset button in `JoystickCustomDirectionPanel.swift`

---
*PR created automatically by Jules for task [15684557983444628158](https://jules.google.com/task/15684557983444628158) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SwiftUI accessibility pattern documentation for tooltip and screen reader label integration

* **New Features**
  * Enhanced accessibility labels across button mapping, action controls, trial countdown, and joystick settings with context-aware descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->