### PR TITLE
🎨 Palette: Add dynamic accessibility labels to list item action buttons

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit in shared library")
-            .accessibilityLabel("Edit in shared library")
+            .help("Edit \(macro.name) in shared library")
+            .accessibilityLabel("Edit \(macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(macro.name)")
+                .accessibilityLabel("Edit \(macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(macro.name)")
+                .accessibilityLabel("Delete \(macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
             }
         }
         .padding(.horizontal, 12)


### PR DESCRIPTION
💡 What: Added dynamic item names to the accessibility labels and help tooltips for the "Edit" and "Delete" icon-only buttons in `MacroListView` and `ScriptListView`.
🎯 Why: In lists with repeating icon buttons, standard labels like "Edit" provide no context. Screen readers and users hovering over the button will now receive explicit context (e.g., "Edit My Script" instead of just "Edit"), making the interface much more accessible and intuitive.
📸 Before/After: Visuals are unchanged; tooltips and screen reader callouts are improved.
♿ Accessibility: Ensures that list action items are completely unambiguous for VoiceOver users and provides clear hover context.

---
*PR created automatically by Jules for task [4690528951287490734](https://jules.google.com/task/4690528951287490734) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button labels and help text in macro and script lists so they now include the specific item name, making actions clearer.
  * Shared macro actions now reference the shared macro name instead of generic text.
  * Script actions now fall back to “Untitled Script” when a script name is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->