### PR TITLE
🎨 Palette: Disambiguate list actions with dynamic accessibility labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
+
+## 2024-06-27 - [Disambiguating List Actions]
+**Learning:** In repeated lists (like quick text, apps, or links), icon-only buttons with static accessibility labels (e.g., "Edit app") sound identical to screen reader users, making it impossible to know *which* item is being targeted.
+**Action:** Always use dynamic context from the current item in the iteration (e.g., `.accessibilityLabel("Edit \(item.displayName)")`) to disambiguate repeated list actions for assistive technologies.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
@@ -116,7 +116,7 @@ struct QuickTextRowView<SuggestionsView: View>: View {
                     }
                     .buttonStyle(.borderless)
                     .help("Edit quick text")
-                    .accessibilityLabel("Edit quick text")
+                    .accessibilityLabel("Edit \(quickText.text)")
 
                     Button(action: onDelete) {
                         Image(systemName: "trash")
@@ -124,7 +124,7 @@ struct QuickTextRowView<SuggestionsView: View>: View {
                     }
                     .buttonStyle(.borderless)
                     .help("Delete quick text")
-                    .accessibilityLabel("Delete quick text")
+                    .accessibilityLabel("Delete \(quickText.text)")
                 }
             }
 
@@ -195,7 +195,7 @@ struct AppBarItemRowView: View {
             }
             .buttonStyle(.borderless)
             .help("Edit app")
-            .accessibilityLabel("Edit app")
+            .accessibilityLabel("Edit \(item.displayName)")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
@@ -203,7 +203,7 @@ struct AppBarItemRowView: View {
             }
             .buttonStyle(.borderless)
             .help("Delete app")
-            .accessibilityLabel("Delete app")
+            .accessibilityLabel("Delete \(item.displayName)")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
@@ -274,7 +274,7 @@ struct WebsiteLinkRowView: View {
             }
             .buttonStyle(.borderless)
             .help("Edit link")
-            .accessibilityLabel("Edit link")
+            .accessibilityLabel("Edit \(link.displayName)")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
@@ -282,7 +282,7 @@ struct WebsiteLinkRowView: View {
             }
             .buttonStyle(.borderless)
             .help("Delete link")
-            .accessibilityLabel("Delete link")
+            .accessibilityLabel("Delete \(link.displayName)")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
@@ -438,6 +438,7 @@ struct JoystickSettingsView: View {
                     }
                     .buttonStyle(.borderless)
                     .help("Reset to base (inherit)")
+                    .accessibilityLabel("Reset \(label) to inherited")
                 }
             }
 


### PR DESCRIPTION
💡 What: Changed static accessibility labels for icon-only edit/delete buttons in repeated lists to be dynamic by including the item's name/text. Added a missing accessibility label to the reset button in `SettingsViews.swift`.
🎯 Why: In lists of items (like apps, links, or text snippets), screen reader users hear identical static labels like "Edit app" for every row. Adding dynamic context (e.g. "Edit Safari") allows users to know exactly which item they are targeting.
♿ Accessibility: Improves screen reader navigation and clarity for users interacting with settings lists.

Added a learning to `.Jules/palette.md` for this UX pattern.

---
*PR created automatically by Jules for task [8629821849748021373](https://jules.google.com/task/8629821849748021373) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Updated action labels so screen readers now identify the specific item being edited or deleted in repeated lists.
  * Made the reset control’s accessibility label more explicit, clarifying which setting will be restored.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->