### PR TITLE
🎨 Palette: Add accessibility and tooltips to ScriptListView empty state list item buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
+## 2024-06-28 - Missing accessibility in Empty State List Item Buttons
+**Learning:** Empty state list item buttons (like "Add example scripts") containing only an icon or text and icon can miss explicit accessibility labels or helpful tooltips, particularly in dynamically generated lists (`ForEach`) or customized interactive elements, causing a bad UX for mouse and screen reader users.
+**Action:** Always add `.help()` and `.accessibilityLabel()` modifiers to interactive empty state list buttons.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -129,6 +129,8 @@ struct ScriptListView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .help("Add Example Script")
+                .accessibilityLabel("Add Example Script")
             }
 
             HStack(spacing: 12) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -129,8 +129,8 @@ struct ScriptListView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .help("Add Example Script")
-                .accessibilityLabel("Add Example Script")
+                .help("Add \(example.name)")
+                .accessibilityLabel("Add \(example.name)")
             }
 
             HStack(spacing: 12) {


### PR DESCRIPTION
💡 **What**: Added `help` and `accessibilityLabel` modifiers to the button displaying the "+ circle" icon for pre-filling script examples.
🎯 **Why**: Because the UI structure consisted of only an `Image(systemName: "plus.circle")` embedded inside an unlabelled Button (and lacked modifiers), the button action intent was ambiguous for hover interactions on macOS and opaque to VoiceOver screen reader users navigating the empty state.
♿ **Accessibility**: Enhanced the list item buttons to be discoverable and describable for visually impaired screen reader users on macOS.

---
*PR created automatically by Jules for task [11584182886286396162](https://jules.google.com/task/11584182886286396162) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved empty-state list item buttons with clearer tooltips and screen reader labels.
  * The featured example action now includes accessible text for better assistive technology support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->