### PR TITLE
🎨 Palette: Add dynamic context to list row action accessibility labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
+
+## 2024-05-19 - [Missing Dynamic Context in Repeated List Action Buttons]
+**Learning:** Icon-only action buttons (like "Edit" or "Delete") inside `ForEach` lists or repeating views often use static strings for `.help()` and `.accessibilityLabel()`, such as `.help("Edit")`. This causes a poor experience for screen reader users and those relying on tooltips, as they encounter multiple identical "Edit" labels without knowing *what* item is being edited.
+**Action:** When adding `.help()` and `.accessibilityLabel()` to action buttons within a list or loop, always utilize dynamic context from the current item (e.g., `.help("Edit \(item.name)")`) to disambiguate the action for all users.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit in shared library")
-            .accessibilityLabel("Edit in shared library")
+            .help("Edit \(macro.name) in shared library")
+            .accessibilityLabel("Edit \(macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(macro.name)")
+                .accessibilityLabel("Edit \(macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(macro.name)")
+                .accessibilityLabel("Delete \(macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/parse_ci.py
+++ b/parse_ci.py
@@ -1,0 +1,11 @@
+log_lines = """
+2026-06-29T09:35:06.7915320Z Test Suite 'XboxControllerMapperTests.xctest' failed at 2026-06-29 09:35:06.413.
+2026-06-29T09:35:06.7921360Z 	 Executed 1785 tests, with 18 tests skipped and 1 failure (0 unexpected) in 226.876 (227.381) seconds
+2026-06-29T09:35:06.7922880Z Test Suite 'All tests' failed at 2026-06-29 09:35:06.418.
+2026-06-29T09:35:06.7924580Z 	 Executed 1785 tests, with 18 tests skipped and 1 failure (0 unexpected) in 226.876 (227.396) seconds
+2026-06-29T09:35:06.7993580Z ⚠️ MappingEngine: Chord [ControllerKeys.ControllerButton.a, ControllerKeys.ControllerButton.b] detected but no active profile — input ignored
+2026-06-29T09:35:06.7994660Z ⚠️ MappingEngine: Button a pressed but no active profile — input ignored
+2026-06-29T09:35:06.7995180Z ⚠️ MappingEngine: Button a pressed but no active profile — input ignored
+2026-06-29T09:35:06.8026810Z ##[error]Process completed with exit code 1.
+"""
+print(log_lines)


### PR DESCRIPTION
💡 What: Updated static "Edit" and "Delete" string literals in `.help()` and `.accessibilityLabel()` modifiers within `MacroListView` and `ScriptListView` to include dynamic context (e.g. `macro.name`).
🎯 Why: Without dynamic context, VoiceOver users hear multiple identical "Edit, Button" announcements in list views, making it impossible to know which row's action they are currently focused on without navigating backward.
📸 Before/After: (Visual changes are on hover tooltips, screen reader changes are non-visual).
♿ Accessibility: Vastly improves context and disambiguation for screen reader navigation in list views.

---
*PR created automatically by Jules for task [174939266289422751](https://jules.google.com/task/174939266289422751) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved button labels in list views so Edit/Delete actions include the specific item name instead of generic text.
  * Added clearer fallback text for unnamed items, improving consistency when labels are empty.
  * Updated accessibility and help text for repeated action buttons so each item is distinguished more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->