### PR TITLE
🎨 Palette: Add dynamic context to list accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
+## 2026-06-30 - Dynamic Context for Accessibility in Repeated Lists
+**Learning:** When using repeated lists (like `ForEach` loops in SwiftUI), icon-only buttons for actions like Edit and Delete become ambiguous for screen reader users and those relying on pointer tooltips. Using a dynamic context, derived from the item's properties (like `name` or `actionDisplayString`), provides essential context and disambiguates the actions.
+**Action:** Always include item-specific context in `.help()` and `.accessibilityLabel()` modifiers for icon-only buttons within repeated lists.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit in shared library")
-            .accessibilityLabel("Edit in shared library")
+            .help("Edit \(macro.name.isEmpty ? "Untitled Macro" : macro.name) in shared library")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Untitled Macro" : macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(macro.name.isEmpty ? "Untitled Macro" : macro.name)")
+                .accessibilityLabel("Edit \(macro.name.isEmpty ? "Untitled Macro" : macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(macro.name.isEmpty ? "Untitled Macro" : macro.name)")
+                .accessibilityLabel("Delete \(macro.name.isEmpty ? "Untitled Macro" : macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -115,16 +115,16 @@ struct ChordRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit chord \(chord.actionDisplayString)")
+                .accessibilityLabel("Edit chord \(chord.actionDisplayString)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete chord \(chord.actionDisplayString)")
+                .accessibilityLabel("Delete chord \(chord.actionDisplayString)")
             }
         }
         .padding(.horizontal, 12)
@@ -261,16 +261,16 @@ struct SequenceRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit sequence \(sequence.actionDisplayString)")
+                .accessibilityLabel("Edit sequence \(sequence.actionDisplayString)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete sequence \(sequence.actionDisplayString)")
+                .accessibilityLabel("Delete sequence \(sequence.actionDisplayString)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -129,6 +129,8 @@ struct ScriptListView: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .help("Use \(example.name) example")
+                .accessibilityLabel("Use \(example.name) example")
             }
 
             HStack(spacing: 12) {
@@ -222,16 +224,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
             }
         }
         .padding(.horizontal, 12)


### PR DESCRIPTION
🎨 Palette: Add dynamic context to list accessibility

💡 **What:**
Added dynamic, item-specific context to the `.help()` and `.accessibilityLabel()` modifiers on icon-only edit and delete buttons in various list views (`ScriptListView`, `MacroListView`, and `ChordSequenceListViews`).

🎯 **Why:**
When rendering repeated lists (using `ForEach`), providing static "Edit" or "Delete" labels for icon-only buttons makes the interface ambiguous for users relying on screen readers or pointer tooltips, as they lack context on *which* item the action targets. Dynamic context (e.g., "Edit [Macro Name]") disambiguates these actions and significantly improves accessibility.

♿ **Accessibility:**
- Improved screen reader context for list actions.
- Improved tooltip clarity for pointer users.
- Ensured graceful fallbacks for empty names (e.g., "Untitled Macro").

---
*PR created automatically by Jules for task [13112545269818779337](https://jules.google.com/task/13112545269818779337) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added clearer help text and accessibility labels for icon-only actions across macro, chord, sequence, and script lists.
  * Action buttons now include the relevant item name, making edit/delete actions easier to understand with screen readers and tooltips.
  * Empty-state example buttons also gained item-specific accessibility metadata for better clarity.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->