### PR TITLE
🎨 Palette: Add missing accessibility labels to icon buttons

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
@@ -104,6 +104,7 @@ struct QuickTextRowView<SuggestionsView: View>: View {
                                 .font(.caption2)
                                 .foregroundColor(.blue)
                                 .help("Contains variables that will be expanded")
+                                .accessibilityLabel("Contains variables that will be expanded")
                         }
 
                         Spacer()

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
@@ -438,6 +438,7 @@ struct JoystickSettingsView: View {
                     }
                     .buttonStyle(.borderless)
                     .help("Reset to base (inherit)")
+                    .accessibilityLabel("Reset to base (inherit)")
                 }
             }
 


### PR DESCRIPTION
💡 What: Added `.accessibilityLabel` to icon-only buttons in `SettingsViews.swift` (Layer Stick Override reset button) and `OnScreenKeyboardSettingsView.swift` (Variables function icon).
🎯 Why: These buttons previously had `.help` modifiers for hover tooltips but lacked equivalent VoiceOver accessibility labels, making them inaccessible to screen readers.
📸 Before/After: Visuals remain unchanged, but screen reader accessibility is fixed.
♿ Accessibility: Ensures VoiceOver properly announces "Reset to base (inherit)" and "Contains variables that will be expanded" for the respective icons.

---
*PR created automatically by Jules for task [281458812996500947](https://jules.google.com/task/281458812996500947) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen reader support for the on-screen keyboard by adding descriptive labels to the variable indicator and the “Reset to base (inherit)” button.
  * No visible behavior or layout changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->