### PR TITLE
🎨 Palette: Add dynamic accessibility context to list action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,6 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
+## 2026-07-05 - [Dynamic Context for List Actions]
+**Learning:** In repeated lists or loops, action buttons (like Edit/Delete) require dynamic context in their `.help()` and `.accessibilityLabel()` modifiers (e.g., fallback to 'Unnamed' if empty) to disambiguate the action for screen reader users and prevent confusion.
+**Action:** Ensure dynamic labels are applied to all list items.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit in shared library")
-            .accessibilityLabel("Edit in shared library")
+            .help(macro.name.isEmpty ? "Edit in shared library" : "Edit \(macro.name) in shared library")
+            .accessibilityLabel(macro.name.isEmpty ? "Edit in shared library" : "Edit \(macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help(macro.name.isEmpty ? "Edit" : "Edit \(macro.name)")
+                .accessibilityLabel(macro.name.isEmpty ? "Edit" : "Edit \(macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help(macro.name.isEmpty ? "Delete" : "Delete \(macro.name)")
+                .accessibilityLabel(macro.name.isEmpty ? "Delete" : "Delete \(macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help(script.name.isEmpty ? "Edit" : "Edit \(script.name)")
+                .accessibilityLabel(script.name.isEmpty ? "Edit" : "Edit \(script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help(script.name.isEmpty ? "Delete" : "Delete \(script.name)")
+                .accessibilityLabel(script.name.isEmpty ? "Delete" : "Delete \(script.name)")
             }
         }
         .padding(.horizontal, 12)


### PR DESCRIPTION
💡 What: 
Added dynamic context to `.help()` and `.accessibilityLabel()` modifiers for the Edit and Delete buttons in `MacroRow`, `SharedMacroRow`, and `ScriptRow`.

🎯 Why: 
In repeated list views, generic static labels like "Edit" or "Delete" create significant confusion for screen reader users and provide incomplete context via tooltips. By incorporating the specific item's name (e.g., `macro.name` or `script.name`), each button becomes explicitly clear about what action it performs on which item.

♿ Accessibility: 
Resolves a WCAG violation regarding ambiguous control labels in repeated lists. Screen readers will now announce exactly which script or macro is being edited or deleted. Fallback logic is included to ensure empty names do not break string interpolation.

---
*PR created automatically by Jules for task [6052923481835110309](https://jules.google.com/task/6052923481835110309) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Action buttons in list rows now use clearer, item-specific labels and help text.
  * When a name is available, edit and delete actions include it; when not, they fall back to a generic label.
  * This makes repeated items easier to distinguish for screen reader users and improves overall clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->