### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS vulnerability via Process deadlock

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The application was falling back to storing OBS passwords as plaintext strings inside exported/saved JSON models (`Macro.swift` and `SystemCommand.swift`) if saving to the macOS Keychain failed.
 **Learning:** Saving secrets to unencrypted formats simply because secure storage fails is a critical anti-pattern known as "failing open" that results in data exposure.
 **Prevention:** Always fail securely. If secure storage operations fail, discard the sensitive credential in memory rather than writing it insecurely to disk, even if it requires the user to re-authenticate later.
+## 2026-06-26 - [Denial of Service via Subprocess Deadlock]
+**Vulnerability:** The application was vulnerable to an execution deadlock when a spawned shell process emitted output larger than the OS pipe buffer limit (~64KB), causing the `Process` execution framework to hang indefinitely because it called `waitUntilExit()` before reading the pipe.
+**Learning:** If a parent process calls `waitUntilExit()` before fully draining the stdout/stderr pipe, the child process will block indefinitely once the buffer fills up, while the parent is blocked waiting for the child to exit. This is a classic deadlock pattern.
+**Prevention:** When using `Foundation.Process` (or `NSTask`) with `Pipe`, always read the pipe data (e.g., using `readDataToEndOfFile()`) *before* calling `waitUntilExit()`. Alternatively, use asynchronous readability handlers to continuously drain the buffer without blocking the main execution thread.

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,11 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
 
+			// Read pipe data BEFORE waitUntilExit to avoid deadlock when
+			// process output exceeds the pipe buffer size (~64KB).
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Execution framework deadlock/DoS when a spawned process emits large output.
🎯 Impact: An attacker or a misconfigured script could emit >64KB of data to stdout/stderr, causing the application's automation executor to hang indefinitely (deadlock).
🔧 Fix: Reordered the execution flow to read the pipe data before calling `waitUntilExit()`.
✅ Verification: Code statically verified. Issue has been fixed in `SystemCommandExecutor.swift` before, and is now also fixed in `AutomationExecutor.swift`.

---
*PR created automatically by Jules for task [917862636345387285](https://jules.google.com/task/917862636345387285) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where long-running process output could cause the app to hang while waiting for completion.
  * Improved process handling so output is collected before waiting for the process to exit, reducing deadlock risk.

* **Documentation**
  * Added guidance describing the safe way to handle process output when working with external commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->