### PR TITLE
🎨 Palette: Add contextual disambiguation to list action tooltips and accessibility labels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
+
+## 2024-07-06 - [Contextual Accessibility on Repeated List Actions]
+**Learning:** Icon-only buttons in repeated lists (like "Edit" or "Delete" in lists of Macros, Scripts, or Gestures) often lack contextual disambiguation in their VoiceOver labels and tooltips. When all list items just say "Edit" and "Delete", screen reader users lose context on which item they are operating on.
+**Action:** Always append dynamic context from the current list item (e.g. `macro.name.isEmpty ? "Unnamed Macro" : macro.name`) to `.help()` and `.accessibilityLabel()` strings for list actions.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit in shared library")
-            .accessibilityLabel("Edit in shared library")
+            .help("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name) in shared library")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
+                .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
+                .accessibilityLabel("Delete \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -115,16 +115,16 @@ struct ChordRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(chord.hasAction ? "Chord" : "Empty Chord")")
+                .accessibilityLabel("Edit \(chord.hasAction ? "Chord" : "Empty Chord")")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(chord.hasAction ? "Chord" : "Empty Chord")")
+                .accessibilityLabel("Delete \(chord.hasAction ? "Chord" : "Empty Chord")")
             }
         }
         .padding(.horizontal, 12)
@@ -261,16 +261,16 @@ struct SequenceRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(chord.hasAction ? "Chord" : "Empty Chord")")
+                .accessibilityLabel("Edit \(chord.hasAction ? "Chord" : "Empty Chord")")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(chord.hasAction ? "Chord" : "Empty Chord")")
+                .accessibilityLabel("Delete \(chord.hasAction ? "Chord" : "Empty Chord")")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -115,16 +115,16 @@ struct ChordRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help(chord.hasAction ? "Edit Chord" : "Edit Empty Chord")
-                .accessibilityLabel(chord.hasAction ? "Edit Chord" : "Edit Empty Chord")
+                .help("Edit")
+                .accessibilityLabel("Edit")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help(chord.hasAction ? "Delete Chord" : "Delete Empty Chord")
-                .accessibilityLabel(chord.hasAction ? "Delete Chord" : "Delete Empty Chord")
+                .help("Delete")
+                .accessibilityLabel("Delete")
             }
         }
         .padding(.horizontal, 12)
@@ -261,16 +261,16 @@ struct SequenceRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help(sequence.hasAction ? "Edit Sequence" : "Edit Empty Sequence")
-                .accessibilityLabel(sequence.hasAction ? "Edit Sequence" : "Edit Empty Sequence")
+                .help("Edit")
+                .accessibilityLabel("Edit")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help(sequence.hasAction ? "Delete Sequence" : "Delete Empty Sequence")
-                .accessibilityLabel(sequence.hasAction ? "Delete Sequence" : "Delete Empty Sequence")
+                .help("Delete")
+                .accessibilityLabel("Delete")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -115,16 +115,16 @@ struct ChordRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit \(chord.hasAction ? "Chord" : "Empty Chord")")
-                .accessibilityLabel("Edit \(chord.hasAction ? "Chord" : "Empty Chord")")
+                .help(chord.hasAction ? "Edit Chord" : "Edit Empty Chord")
+                .accessibilityLabel(chord.hasAction ? "Edit Chord" : "Edit Empty Chord")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(chord.hasAction ? "Chord" : "Empty Chord")")
-                .accessibilityLabel("Delete \(chord.hasAction ? "Chord" : "Empty Chord")")
+                .help(chord.hasAction ? "Delete Chord" : "Delete Empty Chord")
+                .accessibilityLabel(chord.hasAction ? "Delete Chord" : "Delete Empty Chord")
             }
         }
         .padding(.horizontal, 12)
@@ -261,16 +261,16 @@ struct SequenceRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit \(chord.hasAction ? "Chord" : "Empty Chord")")
-                .accessibilityLabel("Edit \(chord.hasAction ? "Chord" : "Empty Chord")")
+                .help(sequence.hasAction ? "Edit Sequence" : "Edit Empty Sequence")
+                .accessibilityLabel(sequence.hasAction ? "Edit Sequence" : "Edit Empty Sequence")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(chord.hasAction ? "Chord" : "Empty Chord")")
-                .accessibilityLabel("Delete \(chord.hasAction ? "Chord" : "Empty Chord")")
+                .help(sequence.hasAction ? "Delete Sequence" : "Delete Empty Sequence")
+                .accessibilityLabel(sequence.hasAction ? "Delete Sequence" : "Delete Empty Sequence")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/GestureListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/GestureListViews.swift
@@ -78,8 +78,8 @@ struct GestureRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(gestureType.displayName)")
+                .accessibilityLabel("Edit \(gestureType.displayName)")
 
                 if mapping?.hasAction == true {
                     Button(action: onClear) {
@@ -87,8 +87,8 @@ struct GestureRow: View {
                             .foregroundColor(.red.opacity(0.8))
                     }
                     .buttonStyle(.borderless)
-                    .help("Clear")
-                    .accessibilityLabel("Clear")
+                    .help("Clear \(gestureType.displayName)")
+                    .accessibilityLabel("Clear \(gestureType.displayName)")
                 }
             }
         }

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
             }
         }
         .padding(.horizontal, 12)


### PR DESCRIPTION
💡 **What:** The UX enhancement added dynamic context from the current list item (e.g. `macro.name`) to `.help()` tooltips and `.accessibilityLabel()` attributes for icon-only list actions in Macros, Scripts, Gestures, and Chords.

🎯 **Why:** Previously, VoiceOver users and hover tooltips would simply read "Edit" or "Delete" multiple times in a row for repeated list items, making it difficult to disambiguate which item was currently focused. Using dynamic fallback-aware names resolves this ambiguity.

♿ **Accessibility:** Added significant disambiguation to screen reader navigation by ensuring context-aware labeling across all action buttons in the main application lists.


---
*PR created automatically by Jules for task [7251807470675885245](https://jules.google.com/task/7251807470675885245) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved VoiceOver and tooltip context for list actions by including the specific item name in Edit/Delete/Clear labels.
  * Applied this to macros, scripts, and gestures so repeated items are easier to distinguish.
  * Added friendly fallbacks such as “Unnamed Macro” and “Untitled Script” when names are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->