### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Process Deadlocks

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The application was falling back to storing OBS passwords as plaintext strings inside exported/saved JSON models (`Macro.swift` and `SystemCommand.swift`) if saving to the macOS Keychain failed.
 **Learning:** Saving secrets to unencrypted formats simply because secure storage fails is a critical anti-pattern known as "failing open" that results in data exposure.
 **Prevention:** Always fail securely. If secure storage operations fail, discard the sensitive credential in memory rather than writing it insecurely to disk, even if it requires the user to re-authenticate later.
+## 2026-06-26 - [Process Pipe Buffer Deadlock]
+**Vulnerability:** Parent processes executing `Process()` (NSTask) with piped standard output/error were deadlocking if the child output exceeded the OS pipe buffer size (~64KB). The parent process called `waitUntilExit()` before reading the output, causing a classic IPC deadlock.
+**Learning:** This is a DoS risk if an attacker can control or pad the output of commands executed by the application.
+**Prevention:** Always read all data from `Pipe()` objects (e.g., using `readDataToEndOfFile()`) *before* calling `process.waitUntilExit()`.

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,10 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
 
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
+
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +732,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -1405,10 +1405,11 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
             NSLog("[UCMouseRelay] Could not run tailscale status: %@", String(describing: error))
             return []
         }
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
         guard process.terminationStatus == 0 else { return [] }
 
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let peers = object["Peer"] as? [String: Any] else {
             return []


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Process Deadlocks

**Vulnerability:** Parent processes executing `Process()` (NSTask) with piped standard output/error were deadlocking if the child output exceeded the OS pipe buffer size (~64KB). The parent process called `waitUntilExit()` before reading the output, causing a classic IPC deadlock.

**Impact:** This is a DoS risk if an attacker can control or pad the output of commands executed by the application.

**Fix:** Always read all data from `Pipe()` objects (e.g., using `readDataToEndOfFile()`) *before* calling `process.waitUntilExit()`. This prevents the parent process from blocking on the exit signal while the child process blocks on a full pipe buffer.

**Verification:** The code changes were verified to fix the execution ordering issue without modifying the logic of what is read. Static verification passes.

---
*PR created automatically by Jules for task [12262059625694813152](https://jules.google.com/task/12262059625694813152) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when running background processes by reading command output before waiting for the process to finish.
  * Reduced the risk of app hangs caused by waiting on piped output too early.
  * Applied the same fix to process-tree checks and status lookups so command results are handled more safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->