### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Process deadlocks by reading pipes before waitUntilExit

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -18,3 +18,7 @@
 **Vulnerability:** The application was falling back to storing OBS passwords as plaintext strings inside exported/saved JSON models (`Macro.swift` and `SystemCommand.swift`) if saving to the macOS Keychain failed.
 **Learning:** Saving secrets to unencrypted formats simply because secure storage fails is a critical anti-pattern known as "failing open" that results in data exposure.
 **Prevention:** Always fail securely. If secure storage operations fail, discard the sensitive credential in memory rather than writing it insecurely to disk, even if it requires the user to re-authenticate later.
+## 2026-06-25 - [Process Output Pipe Deadlock (DoS)]
+**Vulnerability:** Calling `process.waitUntilExit()` on a `Foundation.Process` while concurrently having the child process write to standard output or standard error without draining the associated `Pipe` can result in a thread deadlock. If the child process output exceeds the OS pipe buffer size (typically ~64KB), the child blocks on writing, and the parent blocks on waiting for the child to exit, freezing the application thread (Denial of Service).
+**Learning:** System pipes have finite capacity. A parent process waiting on a child must actively drain the child's pipes to ensure the child can complete execution and exit.
+**Prevention:** Always read from the `pipe.fileHandleForReading` (e.g., using `readDataToEndOfFile()`) *before* invoking `process.waitUntilExit()`, or use asynchronous pipe reading mechanisms (like `readabilityHandler`).

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -729,13 +728,14 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		let pipe = Pipe()
 		pgrep.standardOutput = pipe
 		pgrep.standardError = FileHandle.nullDevice
+		let data: Data
 		do {
 			try pgrep.run()
+			data = pipe.fileHandleForReading.readDataToEndOfFile()
 			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
-		let data = pipe.fileHandleForReading.readDataToEndOfFile()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -1405,10 +1405,9 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
             NSLog("[UCMouseRelay] Could not run tailscale status: %@", String(describing: error))
             return []
         }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
         guard process.terminationStatus == 0 else { return [] }
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let peers = object["Peer"] as? [String: Any] else {
             return []

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** DoS / Resource Exhaustion via `Foundation.Process` deadlock. When a child process writes more data than the OS pipe buffer capacity (typically ~64KB), the child blocks on writing. If the parent application is simultaneously blocked on `process.waitUntilExit()` without draining the pipe, a thread deadlock occurs, leading to application freeze.
🎯 **Impact:** An attacker or misbehaving automation step could cause the main application thread to hang indefinitely, resulting in a Denial of Service.
🔧 **Fix:** Refactored multiple occurrences across the codebase (`UniversalControlMouseRelay`, `AutomationExecutor`, `OBSWebSocketLiveIntegrationTests`) to always read from `pipe.fileHandleForReading.readDataToEndOfFile()` *before* invoking `process.waitUntilExit()`.
✅ **Verification:** Verified via static code syntax checks and code review that the correct sequence is followed.

---
*PR created automatically by Jules for task [3474175059985067787](https://jules.google.com/task/3474175059985067787) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess handling to prevent rare hangs caused by filled output buffers.
  * Ensured process output is read before waiting for exit in multiple paths, making command execution more reliable.
  * Adjusted binary-path detection to avoid blocking while resolving external tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->