### PR TITLE
🎨 Palette: Improve accessibility of list action buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
+
+## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
+**Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
+**Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit in shared library")
-            .accessibilityLabel("Edit in shared library")
+            .help("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name) in shared library")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
+                .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
+                .accessibilityLabel("Delete \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -115,16 +115,16 @@ struct ChordRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit \(chord.name)")
-                .accessibilityLabel("Edit \(chord.name)")
+                .help("Edit \(chord.buttonsDisplayString)")
+                .accessibilityLabel("Edit \(chord.buttonsDisplayString)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(chord.name)")
-                .accessibilityLabel("Delete \(chord.name)")
+                .help("Delete \(chord.buttonsDisplayString)")
+                .accessibilityLabel("Delete \(chord.buttonsDisplayString)")
             }
         }
         .padding(.horizontal, 12)
@@ -261,16 +261,16 @@ struct SequenceRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit \(sequence.name)")
-                .accessibilityLabel("Edit \(sequence.name)")
+                .help("Edit \(sequence.stepsDisplayString)")
+                .accessibilityLabel("Edit \(sequence.stepsDisplayString)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(sequence.name)")
-                .accessibilityLabel("Delete \(sequence.name)")
+                .help("Delete \(sequence.stepsDisplayString)")
+                .accessibilityLabel("Delete \(sequence.stepsDisplayString)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -115,16 +115,16 @@ struct ChordRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(chord.name)")
+                .accessibilityLabel("Edit \(chord.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(chord.name)")
+                .accessibilityLabel("Delete \(chord.name)")
             }
         }
         .padding(.horizontal, 12)
@@ -261,16 +261,16 @@ struct SequenceRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(sequence.name)")
+                .accessibilityLabel("Edit \(sequence.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(sequence.name)")
+                .accessibilityLabel("Delete \(sequence.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/GestureListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/GestureListViews.swift
@@ -78,8 +78,8 @@ struct GestureRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(gestureType.displayName)")
+                .accessibilityLabel("Edit \(gestureType.displayName)")
 
                 if mapping?.hasAction == true {
                     Button(action: onClear) {
@@ -87,8 +87,8 @@ struct GestureRow: View {
                             .foregroundColor(.red.opacity(0.8))
                     }
                     .buttonStyle(.borderless)
-                    .help("Clear")
-                    .accessibilityLabel("Clear")
+                    .help("Clear \(gestureType.displayName)")
+                    .accessibilityLabel("Clear \(gestureType.displayName)")
                 }
             }
         }

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
             }
         }
         .padding(.horizontal, 12)


### PR DESCRIPTION
💡 What: Added dynamic item names to the `.help()` and `.accessibilityLabel()` strings for list row action buttons (Edit, Delete, Clear) in `MacroListView`, `ChordSequenceListViews`, `GestureListViews`, and `ScriptListView`.
🎯 Why: Previously, VoiceOver would just read "Edit" or "Delete" identically for every row, making it impossible for visually impaired users to know which list item they were operating on. Adding the name provides necessary context.
♿ Accessibility: Major VoiceOver improvement for all main list interfaces, disambiguating repeated action buttons.

---
*PR created automatically by Jules for task [3556881315248094765](https://jules.google.com/task/3556881315248094765) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Updated edit, delete, clear, and shared-library action labels with item-specific names.
  - Added contextual tooltips for macros, chords, sequences, gestures, and scripts.
  - Added fallback labels such as “Unnamed Macro” and “Untitled Script” when names are blank.

- **Documentation**
  - Added guidance for using dynamic labels and tooltips on repeated icon-only list actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->