### PR TITLE
🎨 Palette: Dynamic accessibility labels for list actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,7 +25,3 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
-
-## 2024-07-13 - Dynamic Accessibility Labels in Lists
-**Learning:** Using static labels like "Edit" or "Delete" on icon-only buttons inside lists makes them ambiguous for screen reader users (e.g., hearing "Edit, Edit, Edit").
-**Action:** Always inject contextual names (e.g., `macro.name` or `script.name`) into both `.help()` and `.accessibilityLabel()` for repeated list actions to disambiguate the target. Ensure a fallback exists if the name is empty (e.g., "Untitled").

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -25,3 +25,7 @@
 ## 2026-06-23 - [SwiftUI Button Accessibility]
 **Learning:** Found a pattern where SwiftUI icon-only buttons or minimal UI elements were given `.help()` modifiers for hover tooltips but lacked `.accessibilityLabel()` modifiers for screen readers.
 **Action:** When adding `.help()` to buttons, always pair it with a corresponding `.accessibilityLabel()` to ensure full accessibility.
+
+## 2024-07-13 - Dynamic Accessibility Labels in Lists
+**Learning:** Using static labels like "Edit" or "Delete" on icon-only buttons inside lists makes them ambiguous for screen reader users (e.g., hearing "Edit, Edit, Edit").
+**Action:** Always inject contextual names (e.g., `macro.name` or `script.name`) into both `.help()` and `.accessibilityLabel()` for repeated list actions to disambiguate the target. Ensure a fallback exists if the name is empty (e.g., "Untitled").

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit \(macro.name.isEmpty ? "Unnamed" : macro.name) in shared library")
-            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed" : macro.name) in shared library")
+            .help("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name) in shared library")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit \(macro.name.isEmpty ? "Unnamed" : macro.name)")
-                .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed" : macro.name)")
+                .help("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
+                .accessibilityLabel("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(macro.name.isEmpty ? "Unnamed" : macro.name)")
-                .accessibilityLabel("Delete \(macro.name.isEmpty ? "Unnamed" : macro.name)")
+                .help("Delete \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
+                .accessibilityLabel("Delete \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name) in shared library")
-            .accessibilityLabel("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name) in shared library")
+            .help("Edit " + (macro.name.isEmpty ? "Unnamed" : macro.name) + " in shared library")
+            .accessibilityLabel("Edit " + (macro.name.isEmpty ? "Unnamed" : macro.name) + " in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
-                .accessibilityLabel("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
+                .help("Edit " + (macro.name.isEmpty ? "Unnamed" : macro.name))
+                .accessibilityLabel("Edit " + (macro.name.isEmpty ? "Unnamed" : macro.name))
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
-                .accessibilityLabel("Delete \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
+                .help("Delete " + (macro.name.isEmpty ? "Unnamed" : macro.name))
+                .accessibilityLabel("Delete " + (macro.name.isEmpty ? "Unnamed" : macro.name))
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit in shared library")
-            .accessibilityLabel("Edit in shared library")
+            .help("Edit \(macro.name.isEmpty ? "Unnamed" : macro.name) in shared library")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed" : macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(macro.name.isEmpty ? "Unnamed" : macro.name)")
+                .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed" : macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(macro.name.isEmpty ? "Unnamed" : macro.name)")
+                .accessibilityLabel("Delete \(macro.name.isEmpty ? "Unnamed" : macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -155,8 +155,8 @@ struct SharedMacroRow: View {
                     .foregroundColor(.accentColor)
             }
             .buttonStyle(.borderless)
-            .help("Edit " + (macro.name.isEmpty ? "Unnamed" : macro.name) + " in shared library")
-            .accessibilityLabel("Edit " + (macro.name.isEmpty ? "Unnamed" : macro.name) + " in shared library")
+            .help("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name) in shared library")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name) in shared library")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -206,16 +206,16 @@ struct MacroRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit " + (macro.name.isEmpty ? "Unnamed" : macro.name))
-                .accessibilityLabel("Edit " + (macro.name.isEmpty ? "Unnamed" : macro.name))
+                .help("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
+                .accessibilityLabel("Edit \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete " + (macro.name.isEmpty ? "Unnamed" : macro.name))
-                .accessibilityLabel("Delete " + (macro.name.isEmpty ? "Unnamed" : macro.name))
+                .help("Delete \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
+                .accessibilityLabel("Delete \(macro.name.isEmpty ? \"Unnamed\" : macro.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit")
-                .accessibilityLabel("Edit")
+                .help("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete")
-                .accessibilityLabel("Delete")
+                .help("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .accessibilityLabel("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit " + (script.name.isEmpty ? "Untitled Script" : script.name))
-                .accessibilityLabel("Edit " + (script.name.isEmpty ? "Untitled Script" : script.name))
+                .help("Edit \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
+                .accessibilityLabel("Edit \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete " + (script.name.isEmpty ? "Untitled Script" : script.name))
-                .accessibilityLabel("Delete " + (script.name.isEmpty ? "Untitled Script" : script.name))
+                .help("Delete \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
+                .accessibilityLabel("Delete \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
-                .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .help("Edit \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
+                .accessibilityLabel("Edit \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
-                .accessibilityLabel("Delete \(script.name.isEmpty ? "Untitled Script" : script.name)")
+                .help("Delete \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
+                .accessibilityLabel("Delete \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
             }
         }
         .padding(.horizontal, 12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -222,16 +222,16 @@ struct ScriptRow: View {
                         .foregroundColor(.accentColor)
                 }
                 .buttonStyle(.borderless)
-                .help("Edit \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
-                .accessibilityLabel("Edit \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
+                .help("Edit " + (script.name.isEmpty ? "Untitled Script" : script.name))
+                .accessibilityLabel("Edit " + (script.name.isEmpty ? "Untitled Script" : script.name))
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
                         .foregroundColor(.red.opacity(0.8))
                 }
                 .buttonStyle(.borderless)
-                .help("Delete \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
-                .accessibilityLabel("Delete \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
+                .help("Delete " + (script.name.isEmpty ? "Untitled Script" : script.name))
+                .accessibilityLabel("Delete " + (script.name.isEmpty ? "Untitled Script" : script.name))
             }
         }
         .padding(.horizontal, 12)


### PR DESCRIPTION
💡 **What:** Added dynamic accessibility labels and tooltips to the "Edit" and "Delete" icon-only buttons in `ScriptListView.swift` and `MacroListView.swift`.
🎯 **Why:** Static labels like "Edit" or "Delete" on repeated items in a list make navigation extremely ambiguous for screen reader users (e.g., they just hear "Edit, Edit, Edit"). Injecting the item's name dynamically ("Edit My Macro") disambiguates the actions.
♿ **Accessibility:** Greatly improves screen reader navigation and helps visually-impaired users identify which item they are modifying or deleting.

---
*PR created automatically by Jules for task [3369833062695566997](https://jules.google.com/task/3369833062695566997) started by @NSEvent*