### PR TITLE
🛡️ Sentinel: Fix DoS pipe deadlock in shell execution

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +730,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: When executing shell commands via Foundation.Process, `process.waitUntilExit()` was called before draining the standard output/error pipes (`pipe.fileHandleForReading.readDataToEndOfFile()`). If the shell command outputs more data than the OS pipe buffer capacity (~64KB), the child process hangs waiting for space in the pipe, while the parent hangs waiting for the process to exit.
🎯 Impact: An attacker or a malfunctioning script could trivially cause a Denial of Service by printing a large amount of text, causing the application thread to deadlock indefinitely.
🔧 Fix: Swapped the order so that the pipe buffer is drained completely via `readDataToEndOfFile()` before calling `waitUntilExit()`.
✅ Verification: Statically verified that the data read now correctly precedes the exit wait across instances within `AutomationExecutor.swift`.

---
*PR created automatically by Jules for task [17038624719230680235](https://jules.google.com/task/17038624719230680235) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of command output so results are captured more reliably before processes finish.
  * Enhanced retrieval of child-process information for more consistent automation execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->