### PR TITLE
🎨 Palette: [Make Script Examples Gallery Accessible]

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2024-05-24 - [Accessible List Items]
+**Learning:** Using `.onTapGesture` on list items or cards in SwiftUI breaks keyboard interactivity and drops standard accessibility traits. It prevents users from tabbing to the item or pressing Space/Enter to activate it.
+**Action:** When making elements interactive, wrap them in a `Button` with `.buttonStyle(.plain)` instead of using `.onTapGesture`. This natively supports keyboard navigation and correctly propagates `.help()` and `.accessibilityLabel()` to screen readers.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptExamplesGalleryView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptExamplesGalleryView.swift
@@ -26,11 +26,15 @@ struct ScriptExamplesGalleryView: View {
             ScrollView {
                 LazyVGrid(columns: columns, spacing: 12) {
                     ForEach(ScriptExamplesData.all) { example in
-                        ExampleCard(example: example)
-                            .onTapGesture {
-                                onSelect(example)
-                                dismiss()
-                            }
+                        Button(action: {
+                            onSelect(example)
+                            dismiss()
+                        }) {
+                            ExampleCard(example: example)
+                        }
+                        .buttonStyle(.plain)
+                        .help("Use \(example.name) example")
+                        .accessibilityLabel("Use \(example.name) example")
                     }
                 }
                 .padding()


### PR DESCRIPTION
🎨 Palette: [Make Script Examples Gallery Accessible]

💡 What: Replaced `.onTapGesture` with a `Button` wrapper for ExampleCards in `ScriptExamplesGalleryView.swift`.
🎯 Why: Using `.onTapGesture` prevents keyboard users (tabbing, spacebar to activate) from interacting with the UI. Wrapping it in a Button restores this standard accessibility behavior.
♿ Accessibility: Ensures full keyboard interaction and screen reader support by attaching `.help()` and `.accessibilityLabel()` with dynamic names.

---
*PR created automatically by Jules for task [14496806657667649289](https://jules.google.com/task/14496806657667649289) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard navigation and screen-reader support when selecting script examples.
  * Added clearer accessibility labels and help text for interactive items.
  * Updated selection controls to behave consistently as accessible buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->