### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process pipe deadlock DoS

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,9 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +731,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -166,16 +166,20 @@ private enum OBSMediaMTXManager {
         let outPipe = Pipe()
         which.standardOutput = outPipe
         which.standardError = Pipe()
-        try? which.run()
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        which.waitUntilExit()
-        if which.terminationStatus == 0 {
-            if let path = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-               !path.isEmpty,
-               FileManager.default.isExecutableFile(atPath: path) {
-                return path
+        do {
+            try which.run()
+            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+            which.waitUntilExit()
+            if which.terminationStatus == 0 {
+                if let path = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !path.isEmpty,
+                   FileManager.default.isExecutableFile(atPath: path) {
+                    return path
+                }
             }
+        } catch {
+            // Fall through to throw XCTSkip
         }
 
         throw XCTSkip("mediamtx not found. Install with `brew install mediamtx` or set MEDIAMTX_BIN")

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When spawning a child `Process` (NSTask) and reading its output via a `Pipe`, waiting for the process to exit (`waitUntilExit()`) *before* draining the output pipe buffer creates a race condition. If the output exceeds the OS pipe buffer (~64KB), the child process hangs waiting for the buffer to empty, and the parent hangs waiting for the child to exit, causing a complete application deadlock (Denial of Service).
🎯 Impact: Automation scripts, shell commands, or integration processes that produce large text output will randomly and permanently freeze the host application.
🔧 Fix: Swapped the order to ensure `readDataToEndOfFile()` on the pipe's file handle is called *before* `waitUntilExit()`. This guarantees the buffer is continuously drained until the child process closes its `stdout` streams, avoiding the deadlock entirely. Fix applied across both `AutomationExecutor.swift` and `OBSWebSocketLiveIntegrationTests.swift`.
✅ Verification: `git diff` confirms changes are correctly applied and a static parser verifies syntax brackets are structurally balanced. Code review passed.

---
*PR created automatically by Jules for task [11519980697322531615](https://jules.google.com/task/11519980697322531615) started by @NSEvent*