### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Denial of Service pipe deadlock in TriggerKit

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +730,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Denial of Service pipe deadlock in TriggerKit

🚨 Severity: CRITICAL
💡 Vulnerability: The `AutomationExecutor` in TriggerKit allowed a child process running shell commands to wait to exit (`waitUntilExit()`) before attempting to read its standard output and standard error pipes. If a child process writes more data than the OS pipe buffer can handle (~64KB), the pipe blocks. If the parent is blocked waiting for the child to exit, and the child is blocked waiting for the parent to read the pipe, a deadlock occurs, resulting in an indefinite hang (Denial of Service).
🎯 Impact: Automation flows running extensive shell commands could silently crash the TriggerKit execution runtime, locking up system resources.
🔧 Fix: Drained the pipe by reading standard output before calling `waitUntilExit()`.
✅ Verification: Confirmed through static testing that `waitUntilExit` is only called after draining pipes.

---
*PR created automatically by Jules for task [16938531763685415696](https://jules.google.com/task/16938531763685415696) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process output handling to ensure command results are captured reliably.
  * Prevented potential delays or hangs when collecting standard output and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->