### PR TITLE
🎨 Palette: Improve keyboard accessibility for Macro and Script lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2024-07-17 - [Accessibility] Replaced .onTapGesture with Button for list rows
+**Learning:** Using `.onTapGesture` on list items or interactive rows in SwiftUI prevents proper keyboard navigation and lacks standard accessibility traits for VoiceOver. Wrapping the content in a native `Button` with `.buttonStyle(.plain)` achieves the same visual result while gaining full accessibility support.
+**Action:** Always favor native `Button` wrappers over `.onTapGesture` for interactive UI elements. Remember to maintain the hit area by keeping `.contentShape(Rectangle())` inside the button label.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -179,26 +179,30 @@ struct MacroRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "checklist")
-                    .foregroundColor(.white.opacity(0.3))
-                    .font(.caption)
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(macro.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
-
-                    Text("\(macro.steps.count) steps")
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "checklist")
+                        .foregroundColor(.white.opacity(0.3))
                         .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                        .frame(width: 20)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(macro.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
+
+                        Text("\(macro.steps.count) steps")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
+            .help(macro.name.isEmpty ? "Edit Unnamed Macro" : "Edit \(macro.name)")
+            .accessibilityLabel(macro.name.isEmpty ? "Edit Unnamed Macro" : "Edit \(macro.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -188,33 +188,37 @@ struct ScriptRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "applescript.fill")
-                    .foregroundColor(.orange.opacity(0.6))
-                    .font(.caption)
-                    .frame(width: 20)
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "applescript.fill")
+                        .foregroundColor(.orange.opacity(0.6))
+                        .font(.caption)
+                        .frame(width: 20)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(script.name.isEmpty ? "Untitled Script" : script.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(script.name.isEmpty ? "Untitled Script" : script.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
 
-                    if let description = script.description, !description.isEmpty {
-                        Text(description)
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                            .lineLimit(1)
-                    } else {
-                        Text("\(script.source.count) chars")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
+                        if let description = script.description, !description.isEmpty {
+                            Text(description)
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                                .lineLimit(1)
+                        } else {
+                            Text("\(script.source.count) chars")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
                     }
-                }
 
-                Spacer()
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
+            .help(script.name.isEmpty ? "Edit Untitled Script" : "Edit \(script.name)")
+            .accessibilityLabel(script.name.isEmpty ? "Edit Untitled Script" : "Edit \(script.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
💡 What: Replaced `.onTapGesture` with native `Button`s for the interactive rows in `MacroListView` and `ScriptListView`. Applied `.buttonStyle(.plain)` to preserve the visual appearance and maintained the hit area with `.contentShape(Rectangle())`. Added dynamic `.help()` and `.accessibilityLabel()` based on the item's name.
🎯 Why: Using `.onTapGesture` prevents proper keyboard navigation (focusing via Tab and activation via Enter/Space) and hides the element from screen readers as a semantic, actionable component.
♿ Accessibility: The interactive list items are now natively focusable via keyboard, can be activated using standard keys, and are exposed correctly to VoiceOver as buttons with descriptive labels, improving usability for non-mouse users.

---
*PR created automatically by Jules for task [3414900777140749021](https://jules.google.com/task/3414900777140749021) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation and VoiceOver support for macro and script list rows.
  * Made entire row edit areas clearly identifiable as buttons.
  * Preserved full-row tapping while providing appropriate labels, help text, and interaction styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->