### PR TITLE
🛡️ Sentinel: Fix pipe deadlock DoS in process execution

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,10 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
+			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+
 			process.waitUntilExit()
 
-			let data = pipe.fileHandleForReading.readDataToEndOfFile()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +732,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: When executing shell commands via `Foundation.Process`, the app was waiting for the child process to exit before reading its output pipe. If the child process output exceeded the OS pipe buffer size (~64KB), the child would block waiting to write, and the parent would block waiting for the child to exit.
🎯 Impact: This could result in a permanent deadlock and Denial of Service (DoS).
🔧 Fix: Swapped the order to read the pipe buffer `readDataToEndOfFile()` *before* calling `process.waitUntilExit()`.
✅ Verification: Tested statically, verified syntax validity across modified swift files.

---
*PR created automatically by Jules for task [365513411330066729](https://jules.google.com/task/365513411330066729) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of external processes to ensure output is captured reliably after process completion.
  * Improved process discovery and status checks for more dependable automation behavior.

* **Tests**
  * Updated integration test process handling to improve consistency when locating and validating required components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->