### PR TITLE
🎨 Palette: Replace `.onTapGesture` with `Button` in list views for better accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-07-19 - [Replace .onTapGesture with Button]
+**Learning:** Using `.onTapGesture` directly on `HStack` or similar views for row interaction breaks native keyboard navigation (focus, tab order) and standard accessibility traits for screen readers. Using `Button` with `.buttonStyle(.plain)` maintains the expected visual layout while bringing in built-in keyboard interactivity, `.help()`, and `.accessibilityLabel()` support natively.
+**Action:** When implementing clickable list rows or interactive areas, always use `Button` instead of `.onTapGesture` and apply `.buttonStyle(.plain)` to seamlessly integrate into standard lists while retaining full accessibility and keyboard support.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -179,26 +179,30 @@ struct MacroRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "checklist")
-                    .foregroundColor(.white.opacity(0.3))
-                    .font(.caption)
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(macro.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
-
-                    Text("\(macro.steps.count) steps")
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "checklist")
+                        .foregroundColor(.white.opacity(0.3))
                         .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                        .frame(width: 20)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(macro.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
+
+                        Text("\(macro.steps.count) steps")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
+            .help("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -188,33 +188,37 @@ struct ScriptRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "applescript.fill")
-                    .foregroundColor(.orange.opacity(0.6))
-                    .font(.caption)
-                    .frame(width: 20)
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "applescript.fill")
+                        .foregroundColor(.orange.opacity(0.6))
+                        .font(.caption)
+                        .frame(width: 20)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(script.name.isEmpty ? "Untitled Script" : script.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(script.name.isEmpty ? "Untitled Script" : script.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
 
-                    if let description = script.description, !description.isEmpty {
-                        Text(description)
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                            .lineLimit(1)
-                    } else {
-                        Text("\(script.source.count) chars")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
+                        if let description = script.description, !description.isEmpty {
+                            Text(description)
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                                .lineLimit(1)
+                        } else {
+                            Text("\(script.source.count) chars")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
                     }
-                }
 
-                Spacer()
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
+            .help("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+            .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
💡 **What:** 
Replaced standard `HStack` rows equipped with `.onTapGesture` modifiers with semantic `Button` components using `.buttonStyle(.plain)` in `MacroListView.swift` and `ScriptListView.swift`. Added dynamic `.help()` and `.accessibilityLabel()` bindings to these new interactive areas. 

🎯 **Why:** 
Using `.onTapGesture` directly on views effectively breaks native keyboard navigation; these items lose their focus states and are removed from the native tab order. Additionally, without a semantic interactive trait, screen readers struggle to convey what action the user can perform. By migrating to a `Button`, we restore these vital interactive behaviors and accessibility affordances without altering the visual design of the lists.

♿ **Accessibility:**
- Restored keyboard focus and space/enter key interactivity to the list item actions.
- Introduced specific VoiceOver text via `.accessibilityLabel` indicating exactly which macro or script is being edited (e.g., "Edit 'My Script'").
- Added `.help` strings to provide identical context via visual tooltips on hover.

---
*PR created automatically by Jules for task [6216224137302109714](https://jules.google.com/task/6216224137302109714) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard navigation and focus behavior for macro and script rows.
  * Added clearer accessibility labels and help text for editing actions.
  * Preserved separate controls for editing and deleting scripts.
* **Documentation**
  * Added documentation describing the updated accessibility and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->