### PR TITLE
🎨 Palette: Dynamic accessibility labels in settings list views

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2026-07-20 - [Dynamic Accessibility Labels for Quick Settings Items]
+**Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
+**Action:** Always interpolate the dynamic item context (e.g., `item.displayName`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., "Unnamed App").

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
@@ -115,16 +115,16 @@ struct QuickTextRowView<SuggestionsView: View>: View {
                         Image(systemName: "pencil")
                     }
                     .buttonStyle(.borderless)
-                    .help("Edit quick text")
-                    .accessibilityLabel("Edit quick text")
+                    .help("Edit \(quickText.text.isEmpty ? "Unnamed Text" : quickText.text)")
+                    .accessibilityLabel("Edit \(quickText.text.isEmpty ? "Unnamed Text" : quickText.text)")
 
                     Button(action: onDelete) {
                         Image(systemName: "trash")
                             .foregroundColor(.red)
                     }
                     .buttonStyle(.borderless)
-                    .help("Delete quick text")
-                    .accessibilityLabel("Delete quick text")
+                    .help("Delete \(quickText.text.isEmpty ? "Unnamed Text" : quickText.text)")
+                    .accessibilityLabel("Delete \(quickText.text.isEmpty ? "Unnamed Text" : quickText.text)")
                 }
             }
 
@@ -194,16 +194,16 @@ struct AppBarItemRowView: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
-            .help("Edit app")
-            .accessibilityLabel("Edit app")
+            .help("Edit \(item.displayName.isEmpty ? "Unnamed App" : item.displayName)")
+            .accessibilityLabel("Edit \(item.displayName.isEmpty ? "Unnamed App" : item.displayName)")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
-            .help("Delete app")
-            .accessibilityLabel("Delete app")
+            .help("Delete \(item.displayName.isEmpty ? "Unnamed App" : item.displayName)")
+            .accessibilityLabel("Delete \(item.displayName.isEmpty ? "Unnamed App" : item.displayName)")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)
@@ -273,16 +273,16 @@ struct WebsiteLinkRowView: View {
                 Image(systemName: "pencil")
             }
             .buttonStyle(.borderless)
-            .help("Edit link")
-            .accessibilityLabel("Edit link")
+            .help("Edit \(link.url.isEmpty ? "Unnamed Link" : link.url)")
+            .accessibilityLabel("Edit \(link.url.isEmpty ? "Unnamed Link" : link.url)")
 
             Button(action: onDelete) {
                 Image(systemName: "trash")
                     .foregroundColor(.red)
             }
             .buttonStyle(.borderless)
-            .help("Delete link")
-            .accessibilityLabel("Delete link")
+            .help("Delete \(link.url.isEmpty ? "Unnamed Link" : link.url)")
+            .accessibilityLabel("Delete \(link.url.isEmpty ? "Unnamed Link" : link.url)")
         }
         .padding(.vertical, 4)
         .padding(.horizontal, 8)

--- a/test.swift
+++ b/test.swift
@@ -1,0 +1,4 @@
+struct QuickText { var text: String }
+let quickText = QuickText(text: "Hello")
+let str = "Edit \(quickText.text.isEmpty ? "Unnamed Text" : quickText.text)"
+print(str)

--- a/test2.py
+++ b/test2.py
@@ -1,0 +1,10 @@
+import re
+
+filepath = "./XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift"
+with open(filepath, 'r') as f:
+    content = f.read()
+
+# Let's inspect the code I added
+for line in content.split('\n'):
+    if 'help("Edit' in line or 'accessibilityLabel' in line or 'help("Delete' in line:
+        print(line.strip())


### PR DESCRIPTION
* 💡 **What:** Added dynamic accessibility labels and tooltips to icon-only Edit/Delete buttons in the On-Screen Keyboard Settings view, interpolating context like `item.displayName` or `link.url`.
* 🎯 **Why:** To improve accessibility for screen reader users and provide better context in tooltips. Previously, generic labels like "Edit app" were used, making it ambiguous which item would be affected in a list.
* 📸 **Before/After:** No visual changes. Screen reader/hover experiences improved.
* ♿ **Accessibility:** Replaced static accessibility labels with dynamic ones, resolving a critical VoiceOver UX issue where multiple list items announced identical ambiguous actions. Includes a fallback for empty values (e.g., "Unnamed App").

---
*PR created automatically by Jules for task [16799524390826518447](https://jules.google.com/task/16799524390826518447) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved VoiceOver labels and tooltips for edit and delete controls in Quick Text, app bar, and website link settings.
  * Labels now identify the specific item and provide clear fallback names when details are unavailable.
* **Documentation**
  * Added accessibility guidance for context-aware labels in Quick Settings lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->