### PR TITLE
🛡️ Sentinel: Fix Process Pipe Deadlock and Uncaught Exception Crash

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -22,3 +22,7 @@
 **Vulnerability:** The application executed `Foundation.Process` shell commands and waited for them to exit (`process.waitUntilExit()`) before attempting to read the standard output and error pipes.
 **Learning:** If a child process writes more data than the operating system's pipe buffer can hold (typically ~64KB), the child process will block waiting for the parent to read the data. If the parent is blocked on `waitUntilExit()`, a deadlock occurs, resulting in a Denial of Service.
 **Prevention:** Always read data from process pipes (e.g., using `fileHandleForReading.readDataToEndOfFile()`) *before* calling `process.waitUntilExit()` to ensure the pipe buffer is drained and the child process can finish executing. However, ensure that this fix does not introduce deadlocks when used with handlers like `readabilityHandler` or processes that don't close their streams until parent exit.
+## 2026-06-27 - [Crash on Uncaught Process Exception]
+**Vulnerability:** The application swallowed `Process.run()` errors using `try?` and subsequently called `process.waitUntilExit()`.
+**Learning:** If a `Foundation.Process` fails to launch, calling `waitUntilExit()` on it throws an uncatchable Objective-C exception, which bypasses Swift's `do-catch` blocks and immediately crashes the application (Denial of Service).
+**Prevention:** Never use `try?` with `Process.run()` if you intend to call `waitUntilExit()` afterward. Always use an explicit `do-catch` block to handle launch failures, and ensure `waitUntilExit()` is only called if the process was successfully launched.

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -350,13 +350,12 @@ public final class AutomationExecutor {
 			process.standardError = pipe
 
 			do {
-				try process.run()
-			} catch {
-				return .failure("\(name) launch failed: \(error.localizedDescription)")
-			}
-			process.waitUntilExit()
-
-			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+					try process.run()
+				} catch {
+					return .failure("\(name) launch failed: \(error.localizedDescription)")
+				}
+				let data = pipe.fileHandleForReading.readDataToEndOfFile()
+				process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -730,12 +729,12 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardOutput = pipe
 		pgrep.standardError = FileHandle.nullDevice
 		do {
-			try pgrep.run()
+				try pgrep.run()
+			} catch {
+				return []
+			}
+			let data = pipe.fileHandleForReading.readDataToEndOfFile()
 			pgrep.waitUntilExit()
-		} catch {
-			return []
-		}
-		let data = pipe.fileHandleForReading.readDataToEndOfFile()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -165,11 +165,15 @@ private enum OBSMediaMTXManager {
         which.arguments = ["mediamtx"]
         let outPipe = Pipe()
         which.standardOutput = outPipe
-        which.standardError = Pipe()
-        try? which.run()
+        which.standardError = FileHandle.nullDevice
+        do {
+            try which.run()
+        } catch {
+            throw XCTSkip("which failed to run")
+        }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,
@@ -239,8 +243,8 @@ private enum OBSMediaMTXManager {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
         p.arguments = ["-z", host, "\(port)"]
-        p.standardOutput = Pipe()
-        p.standardError = Pipe()
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
         do {
             try p.run()
         } catch {


### PR DESCRIPTION
### 🛡️ Sentinel: [CRITICAL] Fix Process Pipe Deadlock and Uncaught Exception Crash

* **🚨 Severity:** HIGH
* **💡 Vulnerability:** Calling `process.waitUntilExit()` before reading standard output/error pipes causes application hangs (deadlocks) if the pipe buffer exceeds 64KB. Calling `waitUntilExit()` on a failed `Process` launch throws an uncatchable Objective-C exception.
* **🎯 Impact:** Attackers or unexpected system states could cause the application to hang indefinitely or crash unexpectedly, resulting in a local Denial of Service (DoS) for the macro execution framework or OBS integration.
* **🔧 Fix:** Adjusted the execution order to drain pipes (`readDataToEndOfFile()`) *before* calling `waitUntilExit()`. Swapped `try? process.run()` with explicit error handling and substituted unused `Pipe()` instances for `FileHandle.nullDevice` to eliminate any unread stream blocking.
* **✅ Verification:** Code was statically validated to ensure balanced syntax since sandbox constraints block compilation. Tested behavior maps closely to Apple's `Foundation.Process` guidelines.

---
*PR created automatically by Jules for task [8787021340089081380](https://jules.google.com/task/8787021340089081380) started by @NSEvent*