### PR TITLE
🎨 Palette: Improve accessibility of list items by replacing onTapGesture with Button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-05-18 - [Accessibility] Use Button over .onTapGesture
+**Learning:** In SwiftUI, using `.onTapGesture` for interactive UI elements prevents native keyboard navigability and does not automatically expose standard accessibility traits. This drastically reduces the accessibility of list rows and action items.
+**Action:** Always wrap interactive elements (like rows or cards that perform an action when clicked) in a `Button` with `.buttonStyle(.plain)` to natively support keyboard navigation and fully utilize `.help()` and `.accessibilityLabel()` modifiers.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -179,26 +179,28 @@ struct MacroRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "checklist")
-                    .foregroundColor(.white.opacity(0.3))
-                    .font(.caption)
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(macro.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
-
-                    Text("\(macro.steps.count) steps")
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "checklist")
+                        .foregroundColor(.white.opacity(0.3))
                         .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                        .frame(width: 20)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(macro.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
+
+                        Text("\(macro.steps.count) steps")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
💡 What: Replaced `.onTapGesture` with a `Button` wrapper for list items in `MacroListView.swift`.
🎯 Why: `.onTapGesture` is inaccessible to keyboard users and screen readers. Wrapping the row content in a `Button` allows native keyboard navigation (e.g. Space/Return to activate) and exposes it correctly as an interactive element.
♿ Accessibility: Ensures list rows are fully navigable via VoiceOver and keyboard.

---
*PR created automatically by Jules for task [17216711255853628781](https://jules.google.com/task/17216711255853628781) started by @NSEvent*