### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS pipe deadlock in AutomationExecutor

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -22,3 +22,7 @@
 **Vulnerability:** The application executed `Foundation.Process` shell commands and waited for them to exit (`process.waitUntilExit()`) before attempting to read the standard output and error pipes.
 **Learning:** If a child process writes more data than the operating system's pipe buffer can hold (typically ~64KB), the child process will block waiting for the parent to read the data. If the parent is blocked on `waitUntilExit()`, a deadlock occurs, resulting in a Denial of Service.
 **Prevention:** Always read data from process pipes (e.g., using `fileHandleForReading.readDataToEndOfFile()`) *before* calling `process.waitUntilExit()` to ensure the pipe buffer is drained and the child process can finish executing. However, ensure that this fix does not introduce deadlocks when used with handlers like `readabilityHandler` or processes that don't close their streams until parent exit.
+## 2026-06-27 - [Denial of Service via Pipe Deadlock TriggerKit]
+**Vulnerability:** AutomationExecutor within TriggerKit executed shell commands/pgrep and waited for them to exit (`waitUntilExit()`) before reading the pipe.
+**Learning:** This is a recurring anti-pattern across different modules handling Foundation.Process. Similar to the issue found on 2026-06-26, it blocks the parent process and deadlocks if child output exceeds ~64KB.
+**Prevention:** Consistently audit all uses of Foundation.Process and Pipe across all Swift packages/modules (including TriggerKit, not just the main app), ensuring `readDataToEndOfFile()` precedes `waitUntilExit()`.

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,10 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
 
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
+
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -729,13 +730,14 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		let pipe = Pipe()
 		pgrep.standardOutput = pipe
 		pgrep.standardError = FileHandle.nullDevice
+		let data: Data
 		do {
 			try pgrep.run()
+			data = pipe.fileHandleForReading.readDataToEndOfFile()
 			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
-		let data = pipe.fileHandleForReading.readDataToEndOfFile()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** AutomationExecutor within TriggerKit executes shell commands/pgrep and waits for them to exit (`waitUntilExit()`) before reading the pipe. If child output exceeds ~64KB, the pipe buffer fills up, blocking the child, which in turn blocks the parent indefinitely.
🎯 **Impact:** Potential Denial of Service (DoS) resulting from deadlocks if TriggerKit executes a command emitting large outputs.
🔧 **Fix:** Reordered operations in `AutomationExecutor.swift` to ensure `pipe.fileHandleForReading.readDataToEndOfFile()` is called *before* `process.waitUntilExit()`.
✅ **Verification:** Validated that static syntax checks pass. Code review approved the fix logic.

---
*PR created automatically by Jules for task [17774223866840477895](https://jules.google.com/task/17774223866840477895) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that could cause automation processes to hang when producing substantial command output.
  * Improved process and child-process detection by reading command output before waiting for completion.
* **Documentation**
  * Added guidance for identifying and preventing similar process pipe deadlocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->