### PR TITLE
🎨 Palette: Improve list accessibility in AutomationProgramEditor

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,11 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-05-18 - Convert Interactive UI elements to Buttons
+**Learning:** Found an issue where interactive UI elements (`.onTapGesture`) in a SwiftUI list view lacked keyboard accessibility and VoiceOver support.
+**Action:** Always wrap interactive list items in a `Button` to inherently support standard accessibility traits like VoiceOver activation, focus states, and keyboard navigation.
+
+## 2024-05-18 - Ensure Context-Aware Accessibility and Tooltips for Repeated Elements
+**Learning:** In repeated SwiftUI list rows, icon-only buttons (like Move Up, Move Down, Delete, Collapse) were given generic `.help()` labels and `.accessibilityLabel()`s. This makes the UI ambiguous and highly frustrating for VoiceOver users and screen readers trying to determine which list item the action corresponds to.
+**Action:** Ensure dynamic text interpolation is included for any `.help()` or `.accessibilityLabel()` in a repeated list context, appending a descriptive, context-specific identifier (e.g., `item.name`). Include fallback strings for empty edge-cases.

--- a/TriggerKit/Sources/TriggerKitUI/AutomationProgramEditor.swift
+++ b/TriggerKit/Sources/TriggerKitUI/AutomationProgramEditor.swift
@@ -179,6 +179,7 @@ public struct AutomationProgramEditor: View {
 	private func stepRow(_ step: AutomationStep, at index: Int) -> some View {
 		let allowed = capabilities.allows(step.kind)
 		let expanded = allowed && expandedStepIndexes.contains(index)
+		let itemName = step.displaySummary.isEmpty ? "Unnamed Step" : step.displaySummary
 
 		return VStack(alignment: .leading, spacing: 6) {
 			HStack(spacing: 8) {
@@ -191,25 +192,29 @@ public struct AutomationProgramEditor: View {
 						.frame(width: 16)
 				}
 				.disabled(!allowed)
-				.help(allowed ? (expanded ? "Collapse" : "Expand") : "Unavailable in this host")
-				.accessibilityLabel(allowed ? (expanded ? "Collapse" : "Expand") : "Unavailable in this host")
+				.help(allowed ? (expanded ? "Collapse \(itemName)" : "Expand \(itemName)") : "Unavailable in this host")
+				.accessibilityLabel(allowed ? (expanded ? "Collapse \(itemName)" : "Expand \(itemName)") : "Unavailable in this host")
 
-				HStack(spacing: 8) {
-					Image(systemName: iconName(for: step))
-						.frame(width: 18)
-						.foregroundStyle(allowed ? Color.accentColor : Color.secondary)
-
-					Text(step.displaySummary)
-						.font(.callout.weight(.semibold))
-						.lineLimit(1)
-						.frame(maxWidth: .infinity, alignment: .leading)
-				}
-				.contentShape(Rectangle())
-				.onTapGesture {
+				Button {
 					if allowed {
 						toggleExpanded(index)
 					}
+				} label: {
+					HStack(spacing: 8) {
+						Image(systemName: iconName(for: step))
+							.frame(width: 18)
+							.foregroundStyle(allowed ? Color.accentColor : Color.secondary)
+
+						Text(step.displaySummary)
+							.font(.callout.weight(.semibold))
+							.lineLimit(1)
+							.frame(maxWidth: .infinity, alignment: .leading)
+					}
+					.contentShape(Rectangle())
 				}
+				.buttonStyle(.plain)
+				.help(allowed ? (expanded ? "Collapse \(itemName)" : "Expand \(itemName)") : "Unavailable step")
+				.accessibilityLabel(allowed ? (expanded ? "Collapse \(itemName)" : "Expand \(itemName)") : "Unavailable step")
 
 				Button {
 					moveStep(from: index, by: -1)
@@ -217,8 +222,8 @@ public struct AutomationProgramEditor: View {
 					Image(systemName: "chevron.up")
 				}
 				.disabled(index == 0)
-				.help("Move up")
-				.accessibilityLabel("Move up")
+				.help("Move up \(itemName)")
+				.accessibilityLabel("Move up \(itemName)")
 
 				Button {
 					moveStep(from: index, by: 1)
@@ -226,16 +231,16 @@ public struct AutomationProgramEditor: View {
 					Image(systemName: "chevron.down")
 				}
 				.disabled(index == program.steps.count - 1)
-				.help("Move down")
-				.accessibilityLabel("Move down")
+				.help("Move down \(itemName)")
+				.accessibilityLabel("Move down \(itemName)")
 
 				Button(role: .destructive) {
 					deleteStep(at: index)
 				} label: {
 					Image(systemName: "trash")
 				}
-				.help("Delete")
-				.accessibilityLabel("Delete")
+				.help("Delete \(itemName)")
+				.accessibilityLabel("Delete \(itemName)")
 			}
 			.buttonStyle(.plain)
 


### PR DESCRIPTION
💡 **What:** Improved the list row accessibility inside `AutomationProgramEditor`. Replaced `.onTapGesture` interactions with proper SwiftUI `Button` elements, and integrated the step summary into the tooltips and `accessibilityLabel`s for repeated list actions (e.g. Move up, Move down, Delete, Collapse).

🎯 **Why:** 
1. Using `.onTapGesture` strips the element of built-in focus interactions, breaking standard keyboard navigation for power users.
2. Icon-only buttons with generic labels (like "Delete") repeated down a list view are practically unusable for screen reader users on macOS, as it is impossible to determine *which* item is being acted upon.

📸 **Before/After:** No visible UI styling changes to standard users, but significant functional improvement for keyboard and screen reader accessibility.

♿ **Accessibility:**
- Native keyboard interactivity restored via `Button` component swap.
- VoiceOver will now narrate the context of the action (e.g., "Collapse Step One" instead of generic "Collapse").

---
*PR created automatically by Jules for task [17724803942148747652](https://jules.google.com/task/17724803942148747652) started by @NSEvent*