### PR TITLE
🎨 Palette: Improve list row accessibility with native Button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2026-07-24 - [Replace .onTapGesture with Button]
+**Learning:** Using `.onTapGesture` for list interactive elements causes accessibility and keyboard navigation issues since it lacks native button traits and keyboard support.
+**Action:** Always wrap interactive list items in a `Button` (with `.buttonStyle(.plain)` or similar as needed) instead of applying `.onTapGesture` to ensure full accessibility and keyboard interactivity.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -179,26 +179,28 @@ struct MacroRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "checklist")
-                    .foregroundColor(.white.opacity(0.3))
-                    .font(.caption)
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(macro.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
-
-                    Text("\(macro.steps.count) steps")
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "checklist")
+                        .foregroundColor(.white.opacity(0.3))
                         .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                        .frame(width: 20)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(macro.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
+
+                        Text("\(macro.steps.count) steps")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -188,33 +188,35 @@ struct ScriptRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "applescript.fill")
-                    .foregroundColor(.orange.opacity(0.6))
-                    .font(.caption)
-                    .frame(width: 20)
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "applescript.fill")
+                        .foregroundColor(.orange.opacity(0.6))
+                        .font(.caption)
+                        .frame(width: 20)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(script.name.isEmpty ? "Untitled Script" : script.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(script.name.isEmpty ? "Untitled Script" : script.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
 
-                    if let description = script.description, !description.isEmpty {
-                        Text(description)
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                            .lineLimit(1)
-                    } else {
-                        Text("\(script.source.count) chars")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
+                        if let description = script.description, !description.isEmpty {
+                            Text(description)
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                                .lineLimit(1)
+                        } else {
+                            Text("\(script.source.count) chars")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
                     }
-                }
 
-                Spacer()
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
💡 **What**: Replaced `.onTapGesture` on list items with a `Button` wrapper using `.buttonStyle(.plain)`.
🎯 **Why**: `.onTapGesture` lacks built-in keyboard accessibility and VoiceOver traits. Native buttons solve this without altering the visual hierarchy.
♿ **Accessibility**: Interactive rows can now be triggered via the Spacebar/Return keys and are properly identified to screen readers.

---
*PR created automatically by Jules for task [13288762473225190112](https://jules.google.com/task/13288762473225190112) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for macro list interactions by using native buttons with proper button traits and keyboard support.
  * Preserved the full clickable area for editing macros while maintaining the existing visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->