### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process pipe deadlocks (DoS)

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +730,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: A Denial of Service (DoS) vulnerability existed due to pipe deadlocks in `Process` execution. If a child process writes more data than the OS pipe buffer can hold, it blocks. If the parent is blocked on `waitUntilExit()`, a deadlock occurs.
🎯 Impact: The application could hang indefinitely when executing shell commands or external tools that output large amounts of data.
🔧 Fix: Moved pipe reads (`readDataToEndOfFile()`) to occur *before* calling `process.waitUntilExit()` in `OBSWebSocketLiveIntegrationTests.swift` and `AutomationExecutor.swift`, ensuring the pipe buffer is continuously drained.
✅ Verification: Static code analysis confirms reads happen before waits. Tested with static syntax validation.

---
*PR created automatically by Jules for task [12529352122480999120](https://jules.google.com/task/12529352122480999120) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of shell and system process output to ensure available data is captured reliably before completion checks.
  * Improved reliability when detecting process paths and child processes during automation and integration workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->