### PR TITLE
🎨 Palette: Replace .onTapGesture with Button in MacroListView

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-07-25 - [Accessibility] Replacing .onTapGesture with Button for Semantic Meaning
+**Learning:** In SwiftUI, using `.onTapGesture` on generic views like `HStack` or `VStack` makes the element interactive but strips it of semantic meaning. Screen readers don't recognize it as a button, and it can't be navigated to via keyboard tabbing natively.
+**Action:** Always wrap interactive list items or generic views in a `Button(action: ...)` and apply `.buttonStyle(.plain)` if you don't want the default button styling. This immediately provides keyboard focusability, screen reader support (recognizes it as a button), and allows standard modifiers like `.help()` and `.accessibilityLabel()` to work properly.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -179,26 +179,29 @@ struct MacroRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "checklist")
-                    .foregroundColor(.white.opacity(0.3))
-                    .font(.caption)
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(macro.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
-
-                    Text("\(macro.steps.count) steps")
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "checklist")
+                        .foregroundColor(.white.opacity(0.3))
                         .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                        .frame(width: 20)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(macro.name.isEmpty ? "Unnamed Macro" : macro.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
+
+                        Text("\(macro.steps.count) steps")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
💡 What: Replaced `.onTapGesture` with `Button` in `MacroListView.swift`.
🎯 Why: `.onTapGesture` makes views interactive but strips them of semantic meaning. Replacing it with a `Button` provides keyboard focusability and screen reader support (recognizing it as a button) natively.
♿ Accessibility: Ensure the list item is natively recognized as a button by VoiceOver and keyboard navigation, and added dynamic fallback accessibility labels.

---
*PR created automatically by Jules for task [3909972339696673091](https://jules.google.com/task/3909972339696673091) started by @NSEvent*