### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons in FeedbackKit

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Views/FeedbackKit.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/FeedbackKit.swift
@@ -191,6 +191,7 @@ struct FeedbackFormView: View {
 					.foregroundStyle(.secondary)
 			}
 			.buttonStyle(.plain)
+			.help("Close")
 			.accessibilityLabel("Close")
 		}
 	}
@@ -604,6 +605,7 @@ private struct NudgeCard: View {
 				Image(systemName: "xmark").font(.caption.weight(.bold)).foregroundStyle(.secondary)
 			}
 			.buttonStyle(.plain)
+			.help("Dismiss")
 			.accessibilityLabel("Dismiss")
 		}
 		.padding(12)


### PR DESCRIPTION
💡 What: Added `.help("Close")` and `.help("Dismiss")` tooltips to the icon-only buttons in `FeedbackKit.swift`.
🎯 Why: Ensures symmetry with their `.accessibilityLabel` modifiers, allowing mouse users on macOS to see a tooltip when hovering, making the UI more intuitive.
📸 Before/After: N/A (Tooltips visible on hover)
♿ Accessibility: Ensures full symmetry for icon-only buttons across different interaction vectors.

---
*PR created automatically by Jules for task [14250251978926859617](https://jules.google.com/task/14250251978926859617) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added helpful tooltip text to the feedback window’s close button and the feedback reminder’s dismiss button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->