### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process pipe deadlock vulnerability

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +730,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Process pipe deadlock vulnerability

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The app executed shell commands via `Foundation.Process` and waited for them to exit (`waitUntilExit()`) before attempting to drain the standard output and error pipes.
🎯 **Impact:** If a child process writes more data than the OS pipe buffer can hold (~64KB), the child blocks waiting for the parent to read the data, while the parent is blocked on `waitUntilExit()`, leading to a permanent deadlock and Denial of Service (DoS) of the automation executor thread.
🔧 **Fix:** Reordered the logic to drain the pipe buffer (by calling `pipe.fileHandleForReading.readDataToEndOfFile()`) *before* calling `process.waitUntilExit()` in `runProcess` and `childPIDs(of:)`.
✅ **Verification:** Changes were statically validated to be syntactically correct in a Linux sandbox.

---
*PR created automatically by Jules for task [9185582665077048148](https://jules.google.com/task/9185582665077048148) started by @NSEvent*