### PR TITLE
🎨 Palette: Add keyboard and VoiceOver accessibility to list rows

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2026-07-28 - [Replace onTapGesture with Button for better Accessibility]
+**Learning:** In SwiftUI, using `.onTapGesture` for interactive UI elements lacks built-in keyboard interactivity and standard accessibility traits. Wrapping elements in a `Button` natively supports keyboard navigation and allows use of `.accessibilityLabel()`.
+**Action:** Always prefer wrapping interactive elements in a `Button` over using `.onTapGesture`. Apply `.buttonStyle(.plain)` to avoid introducing default styling while retaining keyboard support.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,6 +29,3 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
-## 2026-07-28 - [Replace onTapGesture with Button for better Accessibility]
-**Learning:** In SwiftUI, using `.onTapGesture` for interactive UI elements lacks built-in keyboard interactivity and standard accessibility traits. Wrapping elements in a `Button` natively supports keyboard navigation and allows use of `.accessibilityLabel()`.
-**Action:** Always prefer wrapping interactive elements in a `Button` over using `.onTapGesture`. Apply `.buttonStyle(.plain)` to avoid introducing default styling while retaining keyboard support.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -179,26 +179,29 @@ struct MacroRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "checklist")
-                    .foregroundColor(.white.opacity(0.3))
-                    .font(.caption)
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(macro.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
-
-                    Text("\(macro.steps.count) steps")
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "checklist")
+                        .foregroundColor(.white.opacity(0.3))
                         .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                        .frame(width: 20)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(macro.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
+
+                        Text("\(macro.steps.count) steps")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -201,7 +201,7 @@ struct MacroRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? \"Unnamed Macro\" : macro.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -201,7 +201,7 @@ struct MacroRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Edit \(macro.name.isEmpty ? \"Unnamed Macro\" : macro.name)")
+            .accessibilityLabel("Edit \(macro.name.isEmpty ? "Unnamed Macro" : macro.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -188,33 +188,36 @@ struct ScriptRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "applescript.fill")
-                    .foregroundColor(.orange.opacity(0.6))
-                    .font(.caption)
-                    .frame(width: 20)
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "applescript.fill")
+                        .foregroundColor(.orange.opacity(0.6))
+                        .font(.caption)
+                        .frame(width: 20)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(script.name.isEmpty ? "Untitled Script" : script.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(script.name.isEmpty ? "Untitled Script" : script.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
 
-                    if let description = script.description, !description.isEmpty {
-                        Text(description)
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                            .lineLimit(1)
-                    } else {
-                        Text("\(script.source.count) chars")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
+                        if let description = script.description, !description.isEmpty {
+                            Text(description)
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                                .lineLimit(1)
+                        } else {
+                            Text("\(script.source.count) chars")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
                     }
-                }
 
-                Spacer()
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -217,7 +217,7 @@ struct ScriptRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Edit \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
+            .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -217,7 +217,7 @@ struct ScriptRow: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Edit \(script.name.isEmpty ? "Untitled Script" : script.name)")
+            .accessibilityLabel("Edit \(script.name.isEmpty ? \"Untitled Script\" : script.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -166,10 +166,14 @@ private enum OBSMediaMTXManager {
         let outPipe = Pipe()
         which.standardOutput = outPipe
         which.standardError = Pipe()
-        try? which.run()
+        do {
+            try which.run()
+        } catch {
+            return nil
+        }
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
💡 **What**: Replaced `.onTapGesture` modifiers with `.buttonStyle(.plain)` wrapped `Button` structures in `ScriptRow` and `MacroRow` components, adding dynamic `.accessibilityLabel()` modifiers based on the item name.\n\n🎯 **Why**: In SwiftUI, elements utilizing `.onTapGesture` are inaccessible to keyboard users (no tab focus) and do not broadcast standard button traits to VoiceOver, making list navigation difficult or impossible for users with accessibility needs. Wrapping the layout in a un-styled `Button` instantly enables keyboard focus and semantic accessibility while perfectly preserving the existing visual layout.\n\n♿ **Accessibility**: Massive improvement for VoiceOver users, who will now hear "Edit [Script/Macro Name], Button" instead of un-actionable, untagged text elements. Full keyboard tab-navigation support added.

---
*PR created automatically by Jules for task [14752838902062056635](https://jules.google.com/task/14752838902062056635) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved edit controls for macros and scripts with clearer button semantics and accessibility labels.
  * Preserved existing layouts, hit areas, and delete controls.

* **Bug Fixes**
  * Improved handling when the system cannot locate the media server executable during integration testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->