### PR TITLE
🎨 Palette: Replace onTapGesture with plain Button for Script items

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2026-07-30 - [Replace onTapGesture with Button]
+**Learning:** Avoid using `.onTapGesture` for interactive UI elements as it lacks keyboard navigability and standard accessibility traits.
+**Action:** Wrap the element in a `Button` using `.buttonStyle(.plain)` to natively support keyboard navigation and fully utilize `.help()` and `.accessibilityLabel()` modifiers.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,6 +29,3 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
-## 2026-07-30 - [Replace onTapGesture with Button]
-**Learning:** Avoid using `.onTapGesture` for interactive UI elements as it lacks keyboard navigability and standard accessibility traits.
-**Action:** Wrap the element in a `Button` using `.buttonStyle(.plain)` to natively support keyboard navigation and fully utilize `.help()` and `.accessibilityLabel()` modifiers.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -188,33 +188,36 @@ struct ScriptRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "applescript.fill")
-                    .foregroundColor(.orange.opacity(0.6))
-                    .font(.caption)
-                    .frame(width: 20)
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "applescript.fill")
+                        .foregroundColor(.orange.opacity(0.6))
+                        .font(.caption)
+                        .frame(width: 20)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(script.name.isEmpty ? "Untitled Script" : script.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(script.name.isEmpty ? "Untitled Script" : script.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
 
-                    if let description = script.description, !description.isEmpty {
-                        Text(description)
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                            .lineLimit(1)
-                    } else {
-                        Text("\(script.source.count) chars")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
+                        if let description = script.description, !description.isEmpty {
+                            Text(description)
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                                .lineLimit(1)
+                        } else {
+                            Text("\(script.source.count) chars")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
                     }
-                }
 
-                Spacer()
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
+            .accessibilityLabel(script.name.isEmpty ? "Edit Untitled Script" : "Edit \(script.name)")
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
Replaced the `.onTapGesture` modifier with a semantic `Button` using `.buttonStyle(.plain)` for the main tappable area of Script items. Added appropriate accessibility labels.

`.onTapGesture` is inaccessible to keyboard navigation and screen readers because it lacks focus state and proper accessibility traits. Wrapping the item in a button solves these issues while retaining the same visual appearance. This change ensures list items can be navigated with the keyboard and clearly identified by VoiceOver.

---
*PR created automatically by Jules for task [9024112586264673861](https://jules.google.com/task/9024112586264673861) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved keyboard navigation for editing scripts.
  * Added descriptive accessibility labels, including a fallback for untitled scripts.
* **Bug Fixes**
  * Updated script row interactions to work correctly with help and accessibility features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->