### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process pipe buffer deadlock DoS

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -351,19 +351,18 @@ public final class AutomationExecutor {
 
 			do {
 				try process.run()
+				let data = pipe.fileHandleForReading.readDataToEndOfFile()
+				process.waitUntilExit()
+				let output = String(data: data, encoding: .utf8)?
+					.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+				if process.terminationStatus == 0 {
+					return .success(success)
+				}
+				return .failure(output.isEmpty ? "\(name) exit \(process.terminationStatus)" : output)
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-
-			let data = pipe.fileHandleForReading.readDataToEndOfFile()
-			process.waitUntilExit()
-			let output = String(data: data, encoding: .utf8)?
-				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-
-			if process.terminationStatus == 0 {
-				return .success(success)
-			}
-			return .failure(output.isEmpty ? "\(name) exit \(process.terminationStatus)" : output)
 		}.value
 	}
 
@@ -731,15 +730,15 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
+			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			pgrep.waitUntilExit()
+			let output = String(data: data, encoding: .utf8) ?? ""
+			return output
+				.split(whereSeparator: \.isNewline)
+				.compactMap { pid_t(String($0).trimmingCharacters(in: .whitespacesAndNewlines)) }
 		} catch {
 			return []
 		}
-		let data = pipe.fileHandleForReading.readDataToEndOfFile()
-		pgrep.waitUntilExit()
-		let output = String(data: data, encoding: .utf8) ?? ""
-		return output
-			.split(whereSeparator: \.isNewline)
-			.compactMap { pid_t(String($0).trimmingCharacters(in: .whitespacesAndNewlines)) }
 	}
 }
 

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,9 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
 
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +731,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -1399,14 +1399,15 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         process.standardOutput = pipe
         process.standardError = FileHandle.nullDevice
 
+        let data: Data
         do {
             try process.run()
+            data = pipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
         } catch {
             NSLog("[UCMouseRelay] Could not run tailscale status: %@", String(describing: error))
             return []
         }
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
         guard process.terminationStatus == 0 else { return [] }
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let peers = object["Peer"] as? [String: Any] else {

--- a/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/Input/UniversalControlMouseRelay.swift
@@ -1397,7 +1397,7 @@ final class UniversalControlMouseRelay: @unchecked Sendable {
         process.arguments = ["status", "--json"]
         let pipe = Pipe()
         process.standardOutput = pipe
-        process.standardError = Pipe()
+        process.standardError = FileHandle.nullDevice
 
         do {
             try process.run()

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -166,17 +166,19 @@ private enum OBSMediaMTXManager {
         let outPipe = Pipe()
         which.standardOutput = outPipe
         which.standardError = FileHandle.nullDevice
-        try? which.run()
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        which.waitUntilExit()
-        if which.terminationStatus == 0 {
-            if let path = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-               !path.isEmpty,
-               FileManager.default.isExecutableFile(atPath: path) {
-                return path
+        do {
+            try which.run()
+            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+            which.waitUntilExit()
+            if which.terminationStatus == 0 {
+                if let path = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !path.isEmpty,
+                   FileManager.default.isExecutableFile(atPath: path) {
+                    return path
+                }
             }
-        }
+        } catch {}
 
         throw XCTSkip("mediamtx not found. Install with `brew install mediamtx` or set MEDIAMTX_BIN")
     }
@@ -243,11 +245,11 @@ private enum OBSMediaMTXManager {
         p.standardError = FileHandle.nullDevice
         do {
             try p.run()
+            p.waitUntilExit()
+            return p.terminationStatus == 0
         } catch {
             return false
         }
-        p.waitUntilExit()
-        return p.terminationStatus == 0
     }
 }
 

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -165,11 +165,11 @@ private enum OBSMediaMTXManager {
         which.arguments = ["mediamtx"]
         let outPipe = Pipe()
         which.standardOutput = outPipe
-        which.standardError = Pipe()
+        which.standardError = FileHandle.nullDevice
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,
@@ -239,8 +239,8 @@ private enum OBSMediaMTXManager {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
         p.arguments = ["-z", host, "\(port)"]
-        p.standardOutput = Pipe()
-        p.standardError = Pipe()
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
         do {
             try p.run()
         } catch {


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Process pipe buffer deadlock DoS

🚨 Severity: CRITICAL
💡 Vulnerability: Child `Process` output exceeding 64KB would fill the pipe buffer and block the child process, while `process.waitUntilExit()` blocked the parent. Unused pipes assigned to `standardError` would also deadlock.
🎯 Impact: Denial of Service (DoS) resulting in permanent application hang.
🔧 Fix: Reordered logic to read pipe data `before` calling `waitUntilExit()`. Swapped unused `Pipe()` instances with `FileHandle.nullDevice` to prevent unmonitored buffers from filling.
✅ Verification: Swift scripts were statically verified to ensure syntax and structure are preserved. Deadlock condition is structurally impossible with unbuffered reading and null device output.

---
*PR created automatically by Jules for task [7649080416497443106](https://jules.google.com/task/7649080416497443106) started by @NSEvent*