### PR TITLE
🎨 Palette: Enhance AddStepRow accessibility using Button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2024-08-01 - Enhance Row Accessibility using Button
+**Learning:** List rows that trigger actions using `.onTapGesture` do not natively expose VoiceOver accessibility traits or support keyboard navigability. While `.onTapGesture` functions visually, it fails basic accessibility standards.
+**Action:** When a custom list row functions as an action, wrap the visual contents in a `Button(action: ...) { ... }`, apply `.buttonStyle(.plain)` to preserve layout and styling, and attach explicit `.help()` and `.accessibilityLabel()` strings for screen reader users and tooltip clarity.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroEditorSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroEditorSheet.swift
@@ -223,18 +223,23 @@ struct AddStepRow: View {
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "plus.circle.fill")
-                .font(.system(size: 16))
-                .foregroundColor(.accentColor)
-            Text("Add Step")
-                .font(.system(size: 13))
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(.accentColor)
+                Text("Add Step")
+                    .font(.system(size: 13))
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 8)
+            .background(isHovered ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor).opacity(0.3))
+            .cornerRadius(6)
+            .contentShape(Rectangle())
         }
-        .frame(maxWidth: .infinity, alignment: .center)
-        .padding(.vertical, 8)
-        .background(isHovered ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor).opacity(0.3))
-        .cornerRadius(6)
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
+        .help("Add a new macro step")
+        .accessibilityLabel("Add Step")
         .onHover { hovering in
             isHovered = hovering
             if hovering {
@@ -242,9 +247,6 @@ struct AddStepRow: View {
             } else {
                 NSCursor.pop()
             }
-        }
-        .onTapGesture {
-            onTap()
         }
     }
 }


### PR DESCRIPTION
💡 What: Refactored `AddStepRow` in `MacroEditorSheet.swift` to use a native `Button` instead of an `HStack` with an `.onTapGesture`. Applied `.buttonStyle(.plain)` to preserve the existing styling while gaining native button traits. Added `.accessibilityLabel` and `.help` for screen readers and tooltips.
🎯 Why: List items and controls that trigger actions using `.onTapGesture` do not natively expose VoiceOver accessibility traits or support keyboard navigability. This fix makes the button accessible to screen readers and keyboard users while preserving the visual interaction logic.
♿ Accessibility: The "Add Step" button is now navigable via keyboard and explicitly read by VoiceOver.

---
*PR created automatically by Jules for task [15772726553061907249](https://jules.google.com/task/15772726553061907249) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard and assistive technology support for adding macro steps.
  * Added descriptive accessibility labels and help text.
* **Bug Fixes**
  * Improved interaction behavior for the add-step control while preserving its existing hover styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->