### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process pipe deadlock DoS

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,9 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +731,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Denial of Service (DoS) via pipe deadlock in `AutomationExecutor.swift` when executing shell processes.
🎯 **Impact:** If an executed shell command generated more standard output than the OS pipe buffer (~64KB), the child process would block waiting for the parent to read. The parent process, waiting on `process.waitUntilExit()`, would be deadlocked, freezing the execution framework and causing a Denial of Service.
🔧 **Fix:** Refactored `runProcess` and `childPIDs` functions to always read data from the pipe (`readDataToEndOfFile()`) *before* calling `process.waitUntilExit()`. This drains the buffer continuously, allowing the child process to complete and successfully exit.
✅ **Verification:** Statically validated Swift syntax logic and dependencies against `AutomationExecutor.swift` and `AutomationExecutorTests.swift`. Verified fixes against Apple's recommended handling of `NSTask`/`Process` pipes.

---
*PR created automatically by Jules for task [10807023161772472851](https://jules.google.com/task/10807023161772472851) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess handling to reliably capture command output and discover child processes before completion.
  * Reduced the risk of missed or incomplete execution results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->