### PR TITLE
🎨 Palette: Replace .onTapGesture with Button for MacroEditorSheet AddStepRow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-06-15 - [Avoid .onTapGesture for Interactive UI Elements]
+**Learning:** Using `.onTapGesture` for interactive UI elements like the "Add Step" row lacks built-in keyboard interactivity and standard accessibility traits.
+**Action:** Instead, wrap the element in a `Button` to natively support keyboard navigation and accessibility. Apply `.buttonStyle(.plain)` if you need to prevent it from introducing default button visual styling.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroEditorSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroEditorSheet.swift
@@ -223,18 +223,21 @@ struct AddStepRow: View {
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "plus.circle.fill")
-                .font(.system(size: 16))
-                .foregroundColor(.accentColor)
-            Text("Add Step")
-                .font(.system(size: 13))
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(.accentColor)
+                Text("Add Step")
+                    .font(.system(size: 13))
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 8)
+            .background(isHovered ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor).opacity(0.3))
+            .cornerRadius(6)
+            .contentShape(Rectangle())
         }
-        .frame(maxWidth: .infinity, alignment: .center)
-        .padding(.vertical, 8)
-        .background(isHovered ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor).opacity(0.3))
-        .cornerRadius(6)
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
         .onHover { hovering in
             isHovered = hovering
             if hovering {
@@ -242,9 +245,6 @@ struct AddStepRow: View {
             } else {
                 NSCursor.pop()
             }
-        }
-        .onTapGesture {
-            onTap()
         }
     }
 }


### PR DESCRIPTION
🎨 Palette: Replace .onTapGesture with Button for MacroEditorSheet AddStepRow

💡 What: Replaced the `.onTapGesture` modifier with a semantic `Button` and `.buttonStyle(.plain)` for the `AddStepRow` in `MacroEditorSheet.swift`.
🎯 Why: `.onTapGesture` on interactive UI elements prevents built-in keyboard interaction (like pressing space/return) and hides the interactive nature from screen readers.
♿ Accessibility: The element is now natively recognized as a button by VoiceOver and can be focused and activated via the keyboard.

---
*PR created automatically by Jules for task [17250655862939852788](https://jules.google.com/task/17250655862939852788) started by @NSEvent*