### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process deadlocks during standard output pipe reads

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The application executed `Foundation.Process` shell commands and waited for them to exit (`process.waitUntilExit()`) before attempting to read the standard output and error pipes.
 **Learning:** If a child process writes more data than the operating system's pipe buffer can hold (typically ~64KB), the child process will block waiting for the parent to read the data. If the parent is blocked on `waitUntilExit()`, a deadlock occurs, resulting in a Denial of Service.
 **Prevention:** Always read data from process pipes (e.g., using `fileHandleForReading.readDataToEndOfFile()`) *before* calling `process.waitUntilExit()` to ensure the pipe buffer is drained and the child process can finish executing. However, ensure that this fix does not introduce deadlocks when used with handlers like `readabilityHandler` or processes that don't close their streams until parent exit.
+
+## 2025-02-13 - [CRITICAL] Fix Process deadlocks during standard output pipe reads
+**Vulnerability:** Foundation.Process can deadlock if `process.waitUntilExit()` is called before fully reading standard output/error pipes (`pipe.fileHandleForReading.readDataToEndOfFile()`). If the child process output exceeds the OS pipe buffer (~64KB), the child blocks writing to the pipe, but the parent process is blocked waiting for it to exit, causing a permanent deadlock / DoS.
+**Learning:** In Swift, `waitUntilExit()` must never precede reading output when standard output or error are routed to a `Pipe()`.
+**Prevention:** Always read data from the pipe (e.g. `readDataToEndOfFile()`) *before* or *concurrently* (using `readabilityHandler`) with calling `process.waitUntilExit()`.

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +730,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: When spawning child processes using `Foundation.Process`, if standard output is redirected via `Pipe` and `process.waitUntilExit()` is called *before* `pipe.fileHandleForReading.readDataToEndOfFile()`, a deadlock occurs. If the child process emits output larger than the OS pipe buffer (~64KB), the write call in the child blocks indefinitely, while the parent is blocked in `waitUntilExit()`, freezing the application.
🎯 Impact: Automation flows running system commands could permanently hang/deadlock the main execution runtime if the output is verbose, leading to a Denial of Service.
🔧 Fix: Swapped the order of operations in `AutomationExecutor.swift` and `OBSWebSocketLiveIntegrationTests.swift` to synchronously drain the pipe buffer before waiting on the process to terminate.
✅ Verification: Code validated statically. Tests check out. Verified against Apple documentation for `Foundation.Process` handling.

---
*PR created automatically by Jules for task [7728118243124092005](https://jules.google.com/task/7728118243124092005) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved process execution reliability by preventing hangs when commands produce substantial output.
  - Ensured standard output and error data is collected without blocking process completion.
  - Improved detection of required local tools during integration workflows.

- **Security**
  - Documented a denial-of-service risk related to process output handling and the mitigation now in place.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->