### PR TITLE
🎨 Palette: Fix SwiftUI keyboard navigability for Macro list rows

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2024-06-25 - [Use semantic Buttons instead of .onTapGesture]
+**Learning:** Using `.onTapGesture` on non-interactive elements like `HStack` or `VStack` breaks keyboard navigability and accessibility traits in SwiftUI.
+**Action:** Wrap the intended interactive content inside a `Button` with an empty action or the desired action, and apply `.buttonStyle(.plain)` or `.buttonStyle(.borderless)` to prevent default styling while retaining interactive states and accessibility support. Remember to move any `.contentShape(Rectangle())` inside the `Button` to ensure the clickable area is maintained.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -179,26 +179,28 @@ struct MacroRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "checklist")
-                    .foregroundColor(.white.opacity(0.3))
-                    .font(.caption)
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(macro.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
-
-                    Text("\(macro.steps.count) steps")
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "checklist")
+                        .foregroundColor(.white.opacity(0.3))
                         .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                        .frame(width: 20)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(macro.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
+
+                        Text("\(macro.steps.count) steps")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
💡 What: Replaced `.onTapGesture` with a semantic `Button` in `MacroRow` within `MacroListView.swift`.
🎯 Why: `.onTapGesture` on basic views like `HStack` breaks keyboard accessibility and VoiceOver traits. Using a `Button` with a `.plain` style fixes this while keeping the same visual appearance.
♿ Accessibility: The row content is now correctly exposed as an interactive button to screen readers and is navigable via the keyboard.

---
*PR created automatically by Jules for task [10624296308692619096](https://jules.google.com/task/10624296308692619096) started by @NSEvent*