### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process pipe deadlock DoS vulnerability

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -22,3 +22,8 @@
 **Vulnerability:** The application executed `Foundation.Process` shell commands and waited for them to exit (`process.waitUntilExit()`) before attempting to read the standard output and error pipes.
 **Learning:** If a child process writes more data than the operating system's pipe buffer can hold (typically ~64KB), the child process will block waiting for the parent to read the data. If the parent is blocked on `waitUntilExit()`, a deadlock occurs, resulting in a Denial of Service.
 **Prevention:** Always read data from process pipes (e.g., using `fileHandleForReading.readDataToEndOfFile()`) *before* calling `process.waitUntilExit()` to ensure the pipe buffer is drained and the child process can finish executing. However, ensure that this fix does not introduce deadlocks when used with handlers like `readabilityHandler` or processes that don't close their streams until parent exit.
+
+## 2024-05-24 - [Process Deadlock DoS] Foundation.Process Pipe Buffer Deadlock
+**Vulnerability:** A deadlock vulnerability exists when using `Foundation.Process` with output pipes if `process.waitUntilExit()` is called before `pipe.fileHandleForReading.readDataToEndOfFile()`. If the child process outputs more data than the OS pipe buffer (~64KB) can hold, it will block indefinitely waiting for the buffer to be drained, while the main process blocks indefinitely on `waitUntilExit()`, leading to a Denial of Service.
+**Learning:** `Foundation.Process` does not automatically drain its output pipes. The OS has a limited buffer size for pipes.
+**Prevention:** Always ensure data is read from pipes *before* or *concurrently* (e.g. via `readabilityHandler` or background queues) with calling `process.waitUntilExit()`.

--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -22,8 +22,3 @@
 **Vulnerability:** The application executed `Foundation.Process` shell commands and waited for them to exit (`process.waitUntilExit()`) before attempting to read the standard output and error pipes.
 **Learning:** If a child process writes more data than the operating system's pipe buffer can hold (typically ~64KB), the child process will block waiting for the parent to read the data. If the parent is blocked on `waitUntilExit()`, a deadlock occurs, resulting in a Denial of Service.
 **Prevention:** Always read data from process pipes (e.g., using `fileHandleForReading.readDataToEndOfFile()`) *before* calling `process.waitUntilExit()` to ensure the pipe buffer is drained and the child process can finish executing. However, ensure that this fix does not introduce deadlocks when used with handlers like `readabilityHandler` or processes that don't close their streams until parent exit.
-
-## 2024-05-24 - [Process Deadlock DoS] Foundation.Process Pipe Buffer Deadlock
-**Vulnerability:** A deadlock vulnerability exists when using `Foundation.Process` with output pipes if `process.waitUntilExit()` is called before `pipe.fileHandleForReading.readDataToEndOfFile()`. If the child process outputs more data than the OS pipe buffer (~64KB) can hold, it will block indefinitely waiting for the buffer to be drained, while the main process blocks indefinitely on `waitUntilExit()`, leading to a Denial of Service.
-**Learning:** `Foundation.Process` does not automatically drain its output pipes. The OS has a limited buffer size for pipes.
-**Prevention:** Always ensure data is read from pipes *before* or *concurrently* (e.g. via `readabilityHandler` or background queues) with calling `process.waitUntilExit()`.

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,8 +354,19 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			// Read output concurrently to avoid deadlocks from large output
+			// without blocking on readDataToEndOfFile() before the process exits.
+			var outputData = Data()
+			let outputQueue = DispatchQueue(label: "com.triggerkit.runProcess.output")
+			let readGroup = DispatchGroup()
+			readGroup.enter()
+			outputQueue.async {
+				outputData = pipe.fileHandleForReading.readDataToEndOfFile()
+				readGroup.leave()
+			}
 			process.waitUntilExit()
+			readGroup.wait()
+			let data = outputData
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,19 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			// Read output concurrently to avoid deadlocks from large output
-			// without blocking on readDataToEndOfFile() before the process exits.
-			var outputData = Data()
-			let outputQueue = DispatchQueue(label: "com.triggerkit.runProcess.output")
-			let readGroup = DispatchGroup()
-			readGroup.enter()
-			outputQueue.async {
-				outputData = pipe.fileHandleForReading.readDataToEndOfFile()
-				readGroup.leave()
-			}
+			let data = pipe.fileHandleForReading.readDataToEndOfFile()
 			process.waitUntilExit()
-			readGroup.wait()
-			let data = outputData
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 

--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** A deadlock vulnerability existed in `AutomationExecutor.swift` when executing shell commands. `process.waitUntilExit()` was called *before* the output pipe was fully drained via `readDataToEndOfFile()`. 
🎯 **Impact:** If a child process outputs more data than the macOS pipe buffer size (~64KB), the child process will block indefinitely waiting to write, while the parent process blocks indefinitely on `waitUntilExit()`. This causes a total deadlock and Denial of Service for the application's automation execution engine.
🔧 **Fix:** Reversed the order of operations in `TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift`. `pipe.fileHandleForReading.readDataToEndOfFile()` is now correctly called *before* `process.waitUntilExit()`, ensuring the buffer is drained.
✅ **Verification:** Code was statically analyzed to ensure Swift syntax validity and that the logic correctly mirrors safe pipe consumption patterns documented in existing project files like `SystemCommandExecutor.swift` and `ScriptEngine.swift`.

---
*PR created automatically by Jules for task [16627227929903255827](https://jules.google.com/task/16627227929903255827) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process execution reliability by reading command output before waiting for completion.
  * Prevented potential hangs and denial-of-service conditions when processes produce enough output to fill their pipe buffers.

* **Documentation**
  * Added security guidance covering process output handling and safe termination behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->