### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process pipe deadlock vulnerability

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,9 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
 
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +731,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,
@@ -246,6 +246,8 @@ private enum OBSMediaMTXManager {
         } catch {
             return false
         }
+        _ = (p.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile()
+        _ = (p.standardError as? Pipe)?.fileHandleForReading.readDataToEndOfFile()
         p.waitUntilExit()
         return p.terminationStatus == 0
     }

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -165,7 +165,7 @@ private enum OBSMediaMTXManager {
         which.arguments = ["mediamtx"]
         let outPipe = Pipe()
         which.standardOutput = outPipe
-        which.standardError = Pipe()
+        which.standardError = FileHandle.nullDevice
         try? which.run()
         let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
@@ -239,15 +239,13 @@ private enum OBSMediaMTXManager {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
         p.arguments = ["-z", host, "\(port)"]
-        p.standardOutput = Pipe()
-        p.standardError = Pipe()
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
         do {
             try p.run()
         } catch {
             return false
         }
-        _ = (p.standardOutput as? Pipe)?.fileHandleForReading.readDataToEndOfFile()
-        _ = (p.standardError as? Pipe)?.fileHandleForReading.readDataToEndOfFile()
         p.waitUntilExit()
         return p.terminationStatus == 0
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Deadlock vulnerability when spawning sub-processes via `Foundation.Process` in `AutomationExecutor`. If the child process output exceeds the OS pipe buffer size (~64KB), the child blocks waiting for the pipe to drain. Since the parent called `waitUntilExit()` before reading the pipe, it causes a mutual deadlock (Denial of Service).
🎯 **Impact:** Malicious automation programs or commands generating large outputs could permanently hang the application.
🔧 **Fix:** Read all data from the pipes before calling `process.waitUntilExit()`.
✅ **Verification:** Verified that Swift files are statically correct and test files did not suffer syntax regressions. Code review passed correctly identifying the vulnerability fix pattern.

---
*PR created automatically by Jules for task [10815850338454617264](https://jules.google.com/task/10815850338454617264) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess output handling by ensuring process completion before reading captured output.
  * Prevented incomplete or inconsistent results when executing automations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->