### PR TITLE
🎨 Palette: Improve keyboard accessibility for interactive list rows

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-08-10 - [Keyboard Accessibility] Interactive Empty Spaces
+**Learning:** In SwiftUI, attaching `.onTapGesture` directly to non-interactive container views (like `HStack` representing a list row) breaks keyboard accessibility because the element won't receive focus, missing accessibility traits and preventing users from activating it with Spacebar or Return. Also, simply wrapping it in a standard `Button` can shrink the tappable area if it previously contained `Spacer()` views.
+**Action:** When implementing custom list rows that need to be interactive, wrap the row content in a `Button(action:)` and apply `.buttonStyle(.plain)` to preserve native visual styling while enabling keyboard interaction. To ensure the full row area remains clickable (including empty spaces), ensure `.contentShape(Rectangle())` is applied to the content *inside* the button block.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/OnScreenKeyboardSettingsView.swift
@@ -94,22 +94,24 @@ struct QuickTextRowView<SuggestionsView: View>: View {
                     Button("Cancel", action: onCancel)
                 } else {
                     // Tappable content area
-                    HStack {
-                        Text(quickText.text)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                    Button(action: onStartEdit) {
+                        HStack {
+                            Text(quickText.text)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
 
-                        if quickText.containsVariables {
-                            Image(systemName: "function")
-                                .font(.caption2)
-                                .foregroundColor(.blue)
-                                .help("Contains variables that will be expanded")
+                            if quickText.containsVariables {
+                                Image(systemName: "function")
+                                    .font(.caption2)
+                                    .foregroundColor(.blue)
+                                    .help("Contains variables that will be expanded")
+                            }
+
+                            Spacer()
                         }
-
-                        Spacer()
+                        .contentShape(Rectangle())
                     }
-                    .contentShape(Rectangle())
-                    .onTapGesture { onStartEdit() }
+                    .buttonStyle(.plain)
 
                     Button(action: onStartEdit) {
                         Image(systemName: "pencil")
@@ -167,28 +169,30 @@ struct AppBarItemRowView: View {
                 .frame(width: 20)
 
             // Tappable content area
-            HStack {
-                // App icon
-                if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: item.bundleIdentifier),
-                   let icon = NSWorkspace.shared.icon(forFile: url.path) as NSImage? {
-                    Image(nsImage: icon)
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                } else {
-                    Image(systemName: "app.fill")
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                        .foregroundColor(.secondary)
+            Button(action: onEdit) {
+                HStack {
+                    // App icon
+                    if let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: item.bundleIdentifier),
+                       let icon = NSWorkspace.shared.icon(forFile: url.path) as NSImage? {
+                        Image(nsImage: icon)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                    } else {
+                        Image(systemName: "app.fill")
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Text(item.displayName)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+
+                    Spacer()
                 }
-
-                Text(item.displayName)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-
-                Spacer()
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             Button(action: onEdit) {
                 Image(systemName: "pencil")
@@ -239,35 +243,37 @@ struct WebsiteLinkRowView: View {
                 .frame(width: 20)
 
             // Tappable content area
-            HStack {
-                // Favicon
-                if let data = link.faviconData,
-                   let nsImage = NSImage(data: data) {
-                    Image(nsImage: nsImage)
-                        .resizable()
-                        .frame(width: 24, height: 24)
-                        .cornerRadius(4)
-                } else {
-                    Image(systemName: "globe")
-                        .frame(width: 24, height: 24)
-                        .foregroundColor(.secondary)
-                }
+            Button(action: onEdit) {
+                HStack {
+                    // Favicon
+                    if let data = link.faviconData,
+                       let nsImage = NSImage(data: data) {
+                        Image(nsImage: nsImage)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .cornerRadius(4)
+                    } else {
+                        Image(systemName: "globe")
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.secondary)
+                    }
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(link.displayName)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                    Text(link.domain ?? link.url)
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(link.displayName)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                        Text(link.domain ?? link.url)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
 
-                Spacer()
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             Button(action: onEdit) {
                 Image(systemName: "pencil")


### PR DESCRIPTION
💡 What: Replaced `.onTapGesture` modifiers on interactive list rows in `OnScreenKeyboardSettingsView.swift` with `Button` elements using `.buttonStyle(.plain)`.
🎯 Why: List rows that use `.onTapGesture` do not receive keyboard focus, meaning they cannot be accessed by keyboard-only users. Wrapping them in a native button preserves the visual appearance while natively participating in keyboard navigation (focusable via Tab, activatable via Spacebar/Enter).
♿ Accessibility: Fixes a significant keyboard trap / unreachable interactive element for accessibility and power users.

---
*PR created automatically by Jules for task [15738998028475076946](https://jules.google.com/task/15738998028475076946) started by @NSEvent*