### PR TITLE
🎨 Palette: Fix accessibility and tooltip symmetry on icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2024-11-20 - Ensure Symmetry in Accessibility and Tooltips for SwiftUI Icon Buttons
+**Learning:** In macOS SwiftUI applications, icon-only buttons often have either `.help()` (for hover tooltips) or `.accessibilityLabel()` (for VoiceOver), but frequently lack both. Both are necessary because they serve different user interaction models—`.help` for visual hover feedback and `.accessibilityLabel` for screen readers.
+**Action:** When adding or reviewing icon-only buttons in SwiftUI, always ensure symmetry by defining both `.help("Description")` and `.accessibilityLabel("Description")` to cover all accessibility and usability vectors.

--- a/XboxControllerMapper/XboxControllerMapper/Views/FeedbackKit.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/FeedbackKit.swift
@@ -191,6 +191,7 @@ struct FeedbackFormView: View {
 					.foregroundStyle(.secondary)
 			}
 			.buttonStyle(.plain)
+			.help("Close")
 			.accessibilityLabel("Close")
 		}
 	}
@@ -604,6 +605,7 @@ private struct NudgeCard: View {
 				Image(systemName: "xmark").font(.caption.weight(.bold)).foregroundStyle(.secondary)
 			}
 			.buttonStyle(.plain)
+			.help("Dismiss")
 			.accessibilityLabel("Dismiss")
 		}
 		.padding(12)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LayerLinkedAppsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LayerLinkedAppsSheet.swift
@@ -189,8 +189,8 @@ private struct LayerAppPickerSheet: View {
 						}
 						.buttonStyle(.bordered)
 						.controlSize(.small)
-						.help("Add \(app.name.isEmpty ? \"Unnamed App\" : app.name)")
-						.accessibilityLabel("Add \(app.name.isEmpty ? \"Unnamed App\" : app.name)")
+						.help("Add \(app.name.isEmpty ? "Unnamed App" : app.name)")
+						.accessibilityLabel("Add \(app.name.isEmpty ? "Unnamed App" : app.name)")
 					}
 				}
 				.padding(.vertical, 4)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LayerLinkedAppsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LayerLinkedAppsSheet.swift
@@ -189,6 +189,8 @@ private struct LayerAppPickerSheet: View {
 						}
 						.buttonStyle(.bordered)
 						.controlSize(.small)
+						.help("Add \(app.name.isEmpty ? \"Unnamed App\" : app.name)")
+						.accessibilityLabel("Add \(app.name.isEmpty ? \"Unnamed App\" : app.name)")
 					}
 				}
 				.padding(.vertical, 4)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SettingsViews.swift
@@ -600,6 +600,7 @@ struct JoystickSettingsView: View {
                     }
                     .buttonStyle(.borderless)
                     .help("Reset to base (inherit)")
+                    .accessibilityLabel("Reset to base (inherit)")
                 }
             }
 


### PR DESCRIPTION
🎨 **Palette: Button Accessibility Symmetry Improvements**

💡 **What:** Added missing `.help()` and `.accessibilityLabel()` elements to several icon-only and list action buttons across `FeedbackKit.swift`, `LayerLinkedAppsSheet.swift`, and `SettingsViews.swift`.

🎯 **Why:** To ensure a complete, accessible experience. Many SwiftUI icon-only buttons often get one but not the other—resulting in a poor experience either for mouse users who rely on tooltips, or for VoiceOver users who need accessible screen reader names. Adding the app name directly into the "Add" button label context also clarifies exactly *which* item is being added in the dynamic list.

♿ **Accessibility:**
- Added missing `.help("Close")` and `.help("Dismiss")` to the icon-only buttons in `FeedbackKit` that only had VoiceOver labels.
- Added `.accessibilityLabel("Reset to base (inherit)")` to the joystick reset button in Settings that only had a tooltip.
- Added both `.help("Add [App Name]")` and `.accessibilityLabel("Add [App Name]")` for the add buttons in the Layer Linked Apps picker, resolving ambiguity when navigating via keyboard or VoiceOver.

---
*PR created automatically by Jules for task [4715913429763870971](https://jules.google.com/task/4715913429763870971) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Added descriptive help text and labels to icon-only buttons throughout feedback, contextual prompts, linked-app setup, and layer settings.
  - Improved identification of app-specific “Add” buttons, including a fallback label for unnamed apps.
  - Clarified the reset action for layer overrides with “Reset to base (inherit).”
- **Documentation**
  - Documented accessibility requirements for SwiftUI icon-only buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->