### PR TITLE
🎨 Palette: Replace .onTapGesture with accessible Button in List views

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-11-21 - [SwiftUI Button Accessibility vs .onTapGesture]
+**Learning:** Using `.onTapGesture` on generic views (like `HStack` or `Text`) makes them unclickable via keyboard and invisible as actionable items to VoiceOver users, creating a significant accessibility barrier.
+**Action:** Always wrap interactive list items or generic views in a `Button(action: ...) { ... }` with `.buttonStyle(.plain)` instead of appending `.onTapGesture`. Crucially, preserve `.contentShape(Rectangle())` *inside* the button label to ensure empty space (like `Spacer()`) remains clickable, preventing touch target shrinkage.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroListView.swift
@@ -179,26 +179,28 @@ struct MacroRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "checklist")
-                    .foregroundColor(.white.opacity(0.3))
-                    .font(.caption)
-                    .frame(width: 20)
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(macro.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
-
-                    Text("\(macro.steps.count) steps")
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "checklist")
+                        .foregroundColor(.white.opacity(0.3))
                         .font(.caption)
-                        .foregroundColor(.white.opacity(0.5))
-                }
+                        .frame(width: 20)
 
-                Spacer()
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(macro.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
+
+                        Text("\(macro.steps.count) steps")
+                            .font(.caption)
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -188,33 +188,35 @@ struct ScriptRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "applescript.fill")
-                    .foregroundColor(.orange.opacity(0.6))
-                    .font(.caption)
-                    .frame(width: 20)
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "applescript.fill")
+                        .foregroundColor(.orange.opacity(0.6))
+                        .font(.caption)
+                        .frame(width: 20)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(script.name.isEmpty ? "Untitled Script" : script.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(script.name.isEmpty ? "Untitled Script" : script.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
 
-                    if let description = script.description, !description.isEmpty {
-                        Text(description)
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                            .lineLimit(1)
-                    } else {
-                        Text("\(script.source.count) chars")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
+                        if let description = script.description, !description.isEmpty {
+                            Text(description)
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                                .lineLimit(1)
+                        } else {
+                            Text("\(script.source.count) chars")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
                     }
-                }
 
-                Spacer()
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
🎨 Palette: Replace .onTapGesture with accessible Button in List views

Replaced `.onTapGesture` on list items in `MacroListView` and `ScriptListView` with semantic `Button` components using `.buttonStyle(.plain)`.

By wrapping the `HStack` inside a Button while preserving the `.contentShape(Rectangle())` modifier, this change ensures that:
1. The list items are fully keyboard accessible and discoverable by VoiceOver on macOS.
2. The entire row remains interactable (touch targets don't shrink).
3. Visual styling and layouts remain identical to the original design.

---
*PR created automatically by Jules for task [14282737523449144133](https://jules.google.com/task/14282737523449144133) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Improved interaction and accessibility for macro and script list items.
  * Empty areas within list rows remain clickable.
  * Existing edit and delete controls continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->