### PR TITLE
🎨 Palette: Improve keyboard accessibility for ScriptRow

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,6 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+## 2024-05-18 - [SwiftUI Button Accessibility]
+**Learning:** In SwiftUI, applying `.onTapGesture` to standard layout views like `HStack` overrides or suppresses native accessibility traits, preventing screen readers from recognizing the element as an interactive button. It also limits keyboard navigability.
+**Action:** Always wrap interactive list rows or clickable elements in a native `Button` and apply `.buttonStyle(.plain)` to preserve custom visual styling while inheriting built-in accessibility properties. If the layout requires empty space (like a `Spacer`) to be clickable, ensure `.contentShape(Rectangle())` is preserved *inside* the button wrapper.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Scripts/ScriptListView.swift
@@ -188,33 +188,35 @@ struct ScriptRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                Image(systemName: "applescript.fill")
-                    .foregroundColor(.orange.opacity(0.6))
-                    .font(.caption)
-                    .frame(width: 20)
+            Button(action: onEdit) {
+                HStack {
+                    Image(systemName: "applescript.fill")
+                        .foregroundColor(.orange.opacity(0.6))
+                        .font(.caption)
+                        .frame(width: 20)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(script.name.isEmpty ? "Untitled Script" : script.name)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(.white.opacity(0.9))
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(script.name.isEmpty ? "Untitled Script" : script.name)
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(.white.opacity(0.9))
 
-                    if let description = script.description, !description.isEmpty {
-                        Text(description)
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
-                            .lineLimit(1)
-                    } else {
-                        Text("\(script.source.count) chars")
-                            .font(.caption)
-                            .foregroundColor(.white.opacity(0.5))
+                        if let description = script.description, !description.isEmpty {
+                            Text(description)
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                                .lineLimit(1)
+                        } else {
+                            Text("\(script.source.count) chars")
+                                .font(.caption)
+                                .foregroundColor(.white.opacity(0.5))
+                        }
                     }
-                }
 
-                Spacer()
+                    Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
💡 What: Replaced `.onTapGesture` on the `ScriptRow` HStack with a proper `Button` wrapper using `.buttonStyle(.plain)`.
🎯 Why: Using `.onTapGesture` prevents screen readers from correctly identifying the row as an interactive element and breaks native keyboard navigation/focus mechanisms (like Tab to focus and Space/Return to activate).
♿ Accessibility: The row now receives proper native `isButton` accessibility traits and full keyboard support, while maintaining the exact same visual design.

---
*PR created automatically by Jules for task [11038574183463147328](https://jules.google.com/task/11038574183463147328) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved script list row interactions for better compatibility with SwiftUI accessibility features.
  - Script rows can now be activated using native button behavior, including clickable empty space where applicable.

- **Usability Improvements**
  - Tapping a script row continues to open the edit action.
  - Existing script details and edit/delete controls remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->