### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix process execution crash vulnerability and error handling

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -22,3 +22,7 @@
 **Vulnerability:** The application executed `Foundation.Process` shell commands and waited for them to exit (`process.waitUntilExit()`) before attempting to read the standard output and error pipes.
 **Learning:** If a child process writes more data than the operating system's pipe buffer can hold (typically ~64KB), the child process will block waiting for the parent to read the data. If the parent is blocked on `waitUntilExit()`, a deadlock occurs, resulting in a Denial of Service.
 **Prevention:** Always read data from process pipes (e.g., using `fileHandleForReading.readDataToEndOfFile()`) *before* calling `process.waitUntilExit()` to ensure the pipe buffer is drained and the child process can finish executing. However, ensure that this fix does not introduce deadlocks when used with handlers like `readabilityHandler` or processes that don't close their streams until parent exit.
+## 2024-05-24 - [Uncatchable Objective-C Exception on Process Launch Failure]
+**Vulnerability:** Calling `process.waitUntilExit()` on a `Foundation.Process` after a swallowed `try? process.run()` throws an uncatchable Objective-C exception causing application or test suite crashes.
+**Learning:** `try?` swallows the error, hiding that the process failed to launch. Calling `waitUntilExit()` on an unlaunched process causes a crash.
+**Prevention:** Always handle `try process.run()` explicitly with a `do-catch` block, and ensure `waitUntilExit()` is never called if `run()` fails.

--- a/XboxControllerMapper/XboxControllerMapper/Services/UI/CommandWheelManager.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Services/UI/CommandWheelManager.swift
@@ -565,7 +565,11 @@ class CommandWheelManager: ObservableObject {
             let appleScript = Process()
             appleScript.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
             appleScript.arguments = ["-e", script]
-            try? appleScript.run()
+            do {
+                try appleScript.run()
+            } catch {
+                NSLog("[CommandWheel] Failed to run AppleScript: %@", error.localizedDescription)
+            }
             return
         default:
             // Fallback: just open normally if browser is unknown
@@ -574,7 +578,11 @@ class CommandWheelManager: ObservableObject {
             return
         }
 
-        try? process.run()
-        usageStatsService?.recordLinkOpened()
+        do {
+            try process.run()
+            usageStatsService?.recordLinkOpened()
+        } catch {
+            NSLog("[CommandWheel] Failed to run process: %@", error.localizedDescription)
+        }
     }
 }

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -166,16 +166,20 @@ private enum OBSMediaMTXManager {
         let outPipe = Pipe()
         which.standardOutput = outPipe
         which.standardError = Pipe()
-        try? which.run()
-        which.waitUntilExit()
-        if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-            if let path = String(data: data, encoding: .utf8)?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-               !path.isEmpty,
-               FileManager.default.isExecutableFile(atPath: path) {
-                return path
+        do {
+            try which.run()
+            which.waitUntilExit()
+            if which.terminationStatus == 0 {
+                let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+                if let path = String(data: data, encoding: .utf8)?
+                    .trimmingCharacters(in: .whitespacesAndNewlines),
+                   !path.isEmpty,
+                   FileManager.default.isExecutableFile(atPath: path) {
+                    return path
+                }
             }
+        } catch {
+            // ignore
         }
 
         throw XCTSkip("mediamtx not found. Install with `brew install mediamtx` or set MEDIAMTX_BIN")

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -168,9 +168,9 @@ private enum OBSMediaMTXManager {
         which.standardError = Pipe()
         do {
             try which.run()
+            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             which.waitUntilExit()
             if which.terminationStatus == 0 {
-                let data = outPipe.fileHandleForReading.readDataToEndOfFile()
                 if let path = String(data: data, encoding: .utf8)?
                     .trimmingCharacters(in: .whitespacesAndNewlines),
                    !path.isEmpty,
@@ -247,11 +247,11 @@ private enum OBSMediaMTXManager {
         p.standardError = Pipe()
         do {
             try p.run()
+            p.waitUntilExit()
+            return p.terminationStatus == 0
         } catch {
             return false
         }
-        p.waitUntilExit()
-        return p.terminationStatus == 0
     }
 }
 


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix process execution crash vulnerability and error handling

🚨 Severity: MEDIUM
💡 Vulnerability: Swallowing launch errors with `try? process.run()` and subsequently calling `process.waitUntilExit()` on an unlaunched `Foundation.Process` throws an uncatchable Objective-C exception, causing crashes in the application or test suite.
🎯 Impact: Denial of Service (application crash) if the underlying system command or executable fails to launch.
🔧 Fix: Upgraded `try?` calls to explicit `do-catch` blocks for `process.run()` and `appleScript.run()`. This explicitly catches launch failures, prevents the fatal `waitUntilExit()` call on unlaunched processes, securely logs the error without leaking sensitive context, and prevents secondary actions (e.g., usage statistics) from running erroneously.
✅ Verification: Statically validated Swift syntax for modified files (`CommandWheelManager.swift`, `OBSWebSocketLiveIntegrationTests.swift`).

---
*PR created automatically by Jules for task [11580351719157000319](https://jules.google.com/task/11580351719157000319) started by @NSEvent*