### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Process pipe deadlock in AutomationExecutor

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,9 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
+			let data = pipe.fileHandleForReading.readDataToEndOfFile()
 			process.waitUntilExit()
 
-			let data = pipe.fileHandleForReading.readDataToEndOfFile()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +731,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -165,7 +165,7 @@ private enum OBSMediaMTXManager {
         which.arguments = ["mediamtx"]
         let outPipe = Pipe()
         which.standardOutput = outPipe
-        which.standardError = Pipe()
+        which.standardError = FileHandle.nullDevice
         try? which.run()
         let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
@@ -239,8 +239,8 @@ private enum OBSMediaMTXManager {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
         p.arguments = ["-z", host, "\(port)"]
-        p.standardOutput = Pipe()
-        p.standardError = Pipe()
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
         do {
             try p.run()
         } catch {

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
**Severity:** CRITICAL
**Vulnerability:** The `AutomationExecutor` executed child processes and waited for them to exit (`process.waitUntilExit()`) before attempting to read standard output or error pipes.
**Impact:** If a child process writes more data than the OS pipe buffer can hold (~64KB), the child will block on write. If the parent is blocked on `waitUntilExit()`, a permanent deadlock occurs, leading to a Denial of Service.
**Fix:** Modified `runProcess` and `childPIDs` to consume pipe output using `readDataToEndOfFile()` *before* calling `waitUntilExit()`, ensuring the buffer is drained and the child can complete safely.
**Verification:** Static syntax validation was executed on modified files and related test files (`AutomationExecutorTests.swift`, `AutomationExecutorPolicyTests.swift`).

---
*PR created automatically by Jules for task [10245832723257948522](https://jules.google.com/task/10245832723257948522) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process output handling to ensure results are captured reliably before processes finish.
  * Preserved existing error handling and result parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->