### PR TITLE
🎨 Palette: Dynamic accessibility labels for list item actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-07-28 - [Dynamic Accessibility Labels for List Item Actions]
+**Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
+**Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
@@ -36,7 +36,7 @@ struct LinkedAppsSheet: View {
                             let appInfo = appMonitor.appInfo(for: bundleId)
                             let displayName = appInfo?.name ?? bundleId
 
-                            if let appInfo = appInfo {
+                            if let appInfo = appMonitor.appInfo(for: bundleId) {
                                 if let icon = appInfo.icon {
                                     Image(nsImage: icon)
                                         .resizable()

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
@@ -33,8 +33,8 @@ struct LinkedAppsSheet: View {
                 } else {
                     ForEach(liveProfile.linkedApps, id: \.self) { bundleId in
                         HStack {
-                            let appInfo = appMonitor.appInfo(for: bundleId)
-                            let displayName = appInfo?.name ?? bundleId
+                            let appInfoLocal = appMonitor.appInfo(for: bundleId)
+                            let displayName = appInfoLocal?.name ?? bundleId
 
                             if let appInfo = appMonitor.appInfo(for: bundleId) {
                                 if let icon = appInfo.icon {

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
@@ -57,8 +57,8 @@ struct LinkedAppsSheet: View {
                                     .foregroundColor(.red)
                             }
                             .buttonStyle(.borderless)
-                            .help("Remove")
-                            .accessibilityLabel("Remove Linked App")
+                            .help("Remove \(appInfo?.name ?? bundleId)")
+                            .accessibilityLabel("Remove \(appInfo?.name ?? bundleId)")
                         }
                         .padding(.vertical, 4)
                     }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedAppsSheet.swift
@@ -33,7 +33,10 @@ struct LinkedAppsSheet: View {
                 } else {
                     ForEach(liveProfile.linkedApps, id: \.self) { bundleId in
                         HStack {
-                            if let appInfo = appMonitor.appInfo(for: bundleId) {
+                            let appInfo = appMonitor.appInfo(for: bundleId)
+                            let displayName = appInfo?.name ?? bundleId
+
+                            if let appInfo = appInfo {
                                 if let icon = appInfo.icon {
                                     Image(nsImage: icon)
                                         .resizable()
@@ -57,8 +60,8 @@ struct LinkedAppsSheet: View {
                                     .foregroundColor(.red)
                             }
                             .buttonStyle(.borderless)
-                            .help("Remove \(appInfo?.name ?? bundleId)")
-                            .accessibilityLabel("Remove \(appInfo?.name ?? bundleId)")
+                            .help("Remove \(displayName)")
+                            .accessibilityLabel("Remove \(displayName)")
                         }
                         .padding(.vertical, 4)
                     }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedControllersSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/LinkedControllersSheet.swift
@@ -56,8 +56,8 @@ struct LinkedControllersSheet: View {
                                     .foregroundColor(.red)
                             }
                             .buttonStyle(.borderless)
-                            .help("Remove")
-                            .accessibilityLabel("Remove Linked Controller")
+                            .help("Remove \(binding.displayName)")
+                            .accessibilityLabel("Remove \(binding.displayName)")
                         }
                         .padding(.vertical, 4)
                     }

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SwipeTypingSection.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/SwipeTypingSection.swift
@@ -99,8 +99,8 @@ struct SwipeTypingSection: View {
                                     .foregroundColor(.red)
                             }
                             .buttonStyle(.borderless)
-                            .help("Delete")
-                            .accessibilityLabel("Delete Custom Word")
+                            .help("Delete \(word)")
+                            .accessibilityLabel("Delete \(word)")
                         }
                     }
                 }


### PR DESCRIPTION
🎨 Palette: Dynamic accessibility labels for list item actions

💡 What: Updated the `accessibilityLabel` and `help` modifiers on the "Remove" and "Delete" icon-only buttons across multiple list views (Linked Apps, Linked Controllers, and Custom Dictionary) to include the specific item name being deleted.
🎯 Why: VoiceOver users and mouse users need specific context when interacting with repeated icon buttons in a list. Without this, every button simply says "Remove", making it impossible to know which item is being acted upon.
♿ Accessibility: Provides dynamic context to screen readers and tooltips, significantly improving the usability of list views for users relying on assistive technologies.

---
*PR created automatically by Jules for task [5826683717772095358](https://jules.google.com/task/5826683717772095358) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Removal controls for linked apps now identify the app by name, with a bundle identifier fallback.
  * Linked-controller removal buttons now include the controller’s display name.
  * Custom dictionary word deletion controls now identify the specific word.
  * Updated help text and accessibility labels provide clearer context for repeated action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->