### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix DoS pipe deadlock in AutomationExecutor

### DIFF
--- a/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
+++ b/TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift
@@ -354,9 +354,8 @@ public final class AutomationExecutor {
 			} catch {
 				return .failure("\(name) launch failed: \(error.localizedDescription)")
 			}
-			process.waitUntilExit()
-
 			let data = pipe.fileHandleForReading.readDataToEndOfFile()
+			process.waitUntilExit()
 			let output = String(data: data, encoding: .utf8)?
 				.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
 
@@ -731,11 +730,11 @@ private final class ShellCommandRunner: @unchecked Sendable {
 		pgrep.standardError = FileHandle.nullDevice
 		do {
 			try pgrep.run()
-			pgrep.waitUntilExit()
 		} catch {
 			return []
 		}
 		let data = pipe.fileHandleForReading.readDataToEndOfFile()
+		pgrep.waitUntilExit()
 		let output = String(data: data, encoding: .utf8) ?? ""
 		return output
 			.split(whereSeparator: \.isNewline)


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix DoS pipe deadlock in AutomationExecutor

🚨 Severity: MEDIUM
💡 Vulnerability: The application executed `Foundation.Process` shell commands and waited for them to exit (`process.waitUntilExit()`) before attempting to read the standard output and error pipes.
🎯 Impact: If a child process writes more data than the operating system's pipe buffer can hold (typically ~64KB), the child process will block waiting for the parent to read the data. If the parent is blocked on `waitUntilExit()`, a deadlock occurs, resulting in a Denial of Service.
🔧 Fix: Swapped the order of reading from the pipe and calling `waitUntilExit()` in `TriggerKit/Sources/TriggerKitRuntime/AutomationExecutor.swift` to ensure the pipe buffer is drained and the child process can finish executing.
✅ Verification: Swift syntax validated statically (compiles correctly).

---
*PR created automatically by Jules for task [1720766462584912278](https://jules.google.com/task/1720766462584912278) started by @NSEvent*