### PR TITLE
🎨 Palette: Improve Accessibility for Command Wheel Selection

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -29,3 +29,7 @@
 ## 2024-07-12 - [Dynamic Accessibility Labels for List Item Actions]
 **Learning:** Icon-only buttons (like Edit/Delete) inside lists pose a major accessibility challenge for VoiceOver users when identical labels ("Edit") are repeated without context, making it impossible to know which row is being acted on.
 **Action:** Always interpolate the dynamic item context (e.g., `item.name`) into both `.help()` tooltips and `.accessibilityLabel()` modifiers in repeated SwiftUI lists. Include fallback text for empty states (e.g., `"Unnamed Item"`).
+
+## 2024-05-18 - Replacing .onTapGesture with Button
+**Learning:** Using `.onTapGesture` for interactive UI elements (like list rows) fails to provide standard accessibility traits (e.g., keyboard interactivity, screen reader support) out-of-the-box.
+**Action:** Always wrap interactive list elements in a `Button` with `.buttonStyle(.plain)` instead of appending `.onTapGesture`, ensuring standard accessibility features are natively applied without altering visual styles.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
@@ -130,19 +130,21 @@ struct CommandWheelSettingsView: View {
                     }
                 } else {
                     ForEach(actions) { action in
-                        CommandWheelActionRow(
-                            action: action,
-                            isSelected: selectedItemId == action.id,
-                            onEdit: { editingAction = action },
-							onDelete: {
-								profileManager.removeCommandWheelAction(action, layerId: selectedLayerId)
-							}
-                        )
-						.allowsHitTesting(canEdit)
-                        .onTapGesture {
+                        Button {
                             selectedItemId = action.id
                             editingAction = action
+                        } label: {
+                            CommandWheelActionRow(
+                                action: action,
+                                isSelected: selectedItemId == action.id,
+                                onEdit: { editingAction = action },
+                                onDelete: {
+                                    profileManager.removeCommandWheelAction(action, layerId: selectedLayerId)
+                                }
+                            )
+                            .allowsHitTesting(canEdit)
                         }
+                        .buttonStyle(.plain)
                     }
                 }
 


### PR DESCRIPTION
💡 What: Replaced `.onTapGesture` with a `Button` wrapper on `CommandWheelActionRow` for better accessibility support.
🎯 Why: `.onTapGesture` lacks out-of-the-box support for keyboard navigation and screen readers on macOS, failing to properly expose interactive UI elements.
📸 Before/After: Visual appearance is unmodified thanks to `.buttonStyle(.plain)`.
♿ Accessibility: Wrapping interactive list elements in a standard SwiftUI `Button` natively surfaces standard button accessibility features (like VoiceOver roles and actions).

---
*PR created automatically by Jules for task [17956684602220660997](https://jules.google.com/task/17956684602220660997) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved action-list selection to support standard button behavior, including keyboard navigation and screen reader interaction.

- **Bug Fixes**
  - Preserved edit and delete availability based on the current editing permissions.
  - Fixed action-row selection behavior while maintaining existing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->