### PR TITLE
🎨 Palette: Replace .onTapGesture with Button in MacroEditorSheet for Keyboard/VoiceOver A11y

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,7 @@
 ## 2024-05-18 - [SwiftUI Button Accessibility]
 **Learning:** Using `.onTapGesture` on generic views like `HStack` prevents interactive elements from properly supporting keyboard focus and VoiceOver accessibility.
 **Action:** Always wrap interactive list rows in a `Button` with `.buttonStyle(.plain)` instead of attaching `.onTapGesture` to views, ensuring `.contentShape(Rectangle())` is applied within the button to maintain the clickable area.
+
+## 2024-12-05 - Avoid .onTapGesture on Structural Views for Accessibility
+**Learning:** Using `.onTapGesture` on general layout components (like `HStack` or custom rows) prevents the UI from receiving keyboard focus (Tab navigation) and prevents screen readers (VoiceOver) from recognizing the item as an interactive button. This severely hinders accessibility.
+**Action:** When making custom rows or views interactive, wrap the internal view in a `Button(action: {})` and apply `.buttonStyle(.plain)` to preserve styling, ensuring `.contentShape(Rectangle())` is inside the button label to maintain the clickable area.

--- a/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroEditorSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/Macros/MacroEditorSheet.swift
@@ -95,21 +95,23 @@ struct MacroEditorSheet: View {
             ScrollView {
                 LazyVStack(spacing: 4) {
                     ForEach(Array(identifiedSteps.enumerated()), id: \.element.id) { index, identifiedStep in
-                        MacroStepRow(
-                            step: identifiedStep.step,
-                            index: index,
-                            onDuplicate: { duplicateStep(at: index) },
-                            onDelete: { deleteStep(at: index) }
-                        )
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
-                        .cornerRadius(6)
-                        .contentShape(Rectangle())
-                        .onTapGesture {
+                        Button {
                             editingStepIndex = index
                             showingStepEditor = true
+                        } label: {
+                            MacroStepRow(
+                                step: identifiedStep.step,
+                                index: index,
+                                onDuplicate: { duplicateStep(at: index) },
+                                onDelete: { deleteStep(at: index) }
+                            )
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(Color(nsColor: .controlBackgroundColor).opacity(0.5))
+                            .cornerRadius(6)
+                            .contentShape(Rectangle())
                         }
+                        .buttonStyle(.plain)
                         .onDrag {
                             draggedStep = identifiedStep
                             return NSItemProvider(object: identifiedStep.id.uuidString as NSString)
@@ -223,18 +225,21 @@ struct AddStepRow: View {
     @State private var isHovered = false
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "plus.circle.fill")
-                .font(.system(size: 16))
-                .foregroundColor(.accentColor)
-            Text("Add Step")
-                .font(.system(size: 13))
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(.accentColor)
+                Text("Add Step")
+                    .font(.system(size: 13))
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, 8)
+            .background(isHovered ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor).opacity(0.3))
+            .cornerRadius(6)
+            .contentShape(Rectangle())
         }
-        .frame(maxWidth: .infinity, alignment: .center)
-        .padding(.vertical, 8)
-        .background(isHovered ? Color.accentColor.opacity(0.15) : Color(nsColor: .controlBackgroundColor).opacity(0.3))
-        .cornerRadius(6)
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
         .onHover { hovering in
             isHovered = hovering
             if hovering {
@@ -242,9 +247,6 @@ struct AddStepRow: View {
             } else {
                 NSCursor.pop()
             }
-        }
-        .onTapGesture {
-            onTap()
         }
     }
 }


### PR DESCRIPTION
💡 **What:**
Replaced `.onTapGesture` on the "Add Step" UI element and the `MacroStepRow` view wrapper inside `MacroEditorSheet.swift` with standard `Button` structures using `.buttonStyle(.plain)`.

🎯 **Why:**
Using `.onTapGesture` on general `View` components (like `HStack` or layout blocks) is an accessibility anti-pattern in SwiftUI. It makes elements interactive for pointer devices but prevents them from receiving proper keyboard focus or being identified as actionable buttons by screen readers like VoiceOver. This fix ensures that macros can be edited accessible across input paradigms.

📸 **Before/After:** No visual changes. Preserved `.contentShape(Rectangle())` to maintain exact clickable area and `.onHover` states.

♿ **Accessibility:**
- Enabled Tab key focus navigation for Macro list items.
- Ensured items are correctly identified by VoiceOver as interactive Buttons rather than static groups.

---
*PR created automatically by Jules for task [2796454948074539227](https://jules.google.com/task/2796454948074539227) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard and VoiceOver support when selecting macro steps.
  * Macro step rows and the “Add Step” row now behave as accessible buttons while retaining their existing appearance and interactions.

* **Documentation**
  * Added guidance recommending accessible button-based interactions for structural views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->