### PR TITLE
🛡️ Sentinel: Fix Process Deadlock in Tests

### DIFF
--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -239,8 +239,8 @@ private enum OBSMediaMTXManager {
         let p = Process()
         p.executableURL = URL(fileURLWithPath: "/usr/bin/nc")
         p.arguments = ["-z", host, "\(port)"]
-        p.standardOutput = Pipe()
-        p.standardError = Pipe()
+        p.standardOutput = FileHandle.nullDevice
+        p.standardError = FileHandle.nullDevice
         do {
             try p.run()
         } catch {

--- a/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
+++ b/XboxControllerMapper/XboxControllerMapperTests/OBSWebSocketLiveIntegrationTests.swift
@@ -167,9 +167,9 @@ private enum OBSMediaMTXManager {
         which.standardOutput = outPipe
         which.standardError = Pipe()
         try? which.run()
+        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
         which.waitUntilExit()
         if which.terminationStatus == 0 {
-            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
             if let path = String(data: data, encoding: .utf8)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
                !path.isEmpty,


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix Process Deadlock Vulnerability

🚨 Severity: MEDIUM
💡 Vulnerability: The test `OBSWebSocketLiveIntegrationTests.swift` was calling `which.waitUntilExit()` *before* fully draining the standard output pipe.
🎯 Impact: If the `which` command output exceeds the OS pipe buffer limit (typically 64KB), the child process will block waiting for the parent to read, and the parent will block indefinitely on `waitUntilExit()`, leading to a deadlock and effectively causing a Denial of Service for the test suite.
🔧 Fix: Moved the `readDataToEndOfFile()` call before `waitUntilExit()` to ensure the pipe buffer is safely drained, mirroring fixes already deployed in production code.
✅ Verification: Statically validated that `waitUntilExit` is not called before pipe reads on `Process` instances throughout the codebase.

---
*PR created automatically by Jules for task [16183143289152164354](https://jules.google.com/task/16183143289152164354) started by @NSEvent*