### PR TITLE
🎨 Palette: Improve keyboard interactivity by replacing onTapGesture with Buttons

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -66,8 +66,9 @@ struct ChordRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                HStack(spacing: 4) {
+            Button(action: onEdit) {
+                HStack {
+                    HStack(spacing: 4) {
                     ForEach(Array(chord.buttons).sorted(by: { $0.category.chordDisplayOrder < $1.category.chordDisplayOrder }), id: \.self) { button in
 							ButtonIconView(button: button, isDualSense: isDualSense, isNintendo: isNintendo, isSteamController: isSteamController, isAppleTVRemote: isAppleTVRemote)
                     }
@@ -105,9 +106,10 @@ struct ChordRow: View {
                 }
 
                 Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {
@@ -213,8 +215,9 @@ struct SequenceRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                HStack(spacing: 4) {
+            Button(action: onEdit) {
+                HStack {
+                    HStack(spacing: 4) {
                     ForEach(Array(sequence.steps.enumerated()), id: \.offset) { index, button in
                         if index > 0 {
                             Image(systemName: "arrow.right")
@@ -251,9 +254,10 @@ struct SequenceRow: View {
                 }
 
                 Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandPalette.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandPalette.swift
@@ -263,7 +263,8 @@ struct CommandPaletteView: View {
 
     private func row(_ destination: CommandPaletteDestination, index: Int) -> some View {
         let isSelected = index == selectedIndex
-        return HStack(spacing: 12) {
+        return Button(action: { onSelect(destination); dismiss() }) {
+            HStack(spacing: 12) {
             Image(systemName: destination.systemImage)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundStyle(isSelected ? Color.white : .secondary)
@@ -300,7 +301,8 @@ struct CommandPaletteView: View {
                 .fill(isSelected ? Color.accentColor.opacity(0.16) : Color.clear)
         )
         .contentShape(Rectangle())
-        .onTapGesture { onSelect(destination); dismiss() }
+        }
+        .buttonStyle(.plain)
         .onHover { hovering in if hovering { model.selectedIndex = index } }
     }
 

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/CommandWheelSettingsView.swift
@@ -130,19 +130,21 @@ struct CommandWheelSettingsView: View {
                     }
                 } else {
                     ForEach(actions) { action in
-                        CommandWheelActionRow(
-                            action: action,
-                            isSelected: selectedItemId == action.id,
-                            onEdit: { editingAction = action },
-							onDelete: {
-								profileManager.removeCommandWheelAction(action, layerId: selectedLayerId)
-							}
-                        )
-						.allowsHitTesting(canEdit)
-                        .onTapGesture {
+                        Button(action: {
                             selectedItemId = action.id
                             editingAction = action
+                        }) {
+                            CommandWheelActionRow(
+                                action: action,
+                                isSelected: selectedItemId == action.id,
+                                onEdit: { editingAction = action },
+                                onDelete: {
+                                    profileManager.removeCommandWheelAction(action, layerId: selectedLayerId)
+                                }
+                            )
+                            .allowsHitTesting(canEdit)
                         }
+                        .buttonStyle(.plain)
                     }
                 }
 


### PR DESCRIPTION
**💡 What:**
Replaced `.onTapGesture` usage on interactive list rows and elements with `Button(action: ...) { ... } .buttonStyle(.plain)`.

**🎯 Why:**
In SwiftUI, attaching `.onTapGesture` directly to structural views (like `HStack`) makes them interactive for mouse/touch users but entirely opaque to keyboard navigation (Tab key) and screen readers (VoiceOver). By wrapping the content in a `Button`, the operating system properly recognizes the elements as focusable and actionable controls.

**📸 Before/After:**
*(Visuals remain identical due to `.buttonStyle(.plain)`, but keyboard focus rings will now correctly appear when tabbing).*

**♿ Accessibility:**
- Restores keyboard navigation (tabbing) for Command Palette items, Chord sequence rows, and Command Wheel action items.
- Restores VoiceOver focus and activation for these elements.
- Ensured `.contentShape(Rectangle())` modifiers were preserved inside the button labels to prevent the clickable area from shrinking to just the visible text/icons, avoiding a UX regression for mouse users.

---
*PR created automatically by Jules for task [11718752516912245549](https://jules.google.com/task/11718752516912245549) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Interaction**
  * Improved keyboard and assistive technology support for selectable rows and command palette options.
  * Preserved existing editing, selection, and dismissal behavior when activating items.
  * Maintained visual styling and interaction areas throughout the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->