### PR TITLE
🎨 Palette: [Accessibility] Improve VoiceOver and Keyboard Navigation for Chord and Sequence Lists

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,6 @@
 ## 2024-05-18 - [SwiftUI Button Accessibility]
 **Learning:** Using `.onTapGesture` on generic views like `HStack` prevents interactive elements from properly supporting keyboard focus and VoiceOver accessibility.
 **Action:** Always wrap interactive list rows in a `Button` with `.buttonStyle(.plain)` instead of attaching `.onTapGesture` to views, ensuring `.contentShape(Rectangle())` is applied within the button to maintain the clickable area.
+## 2024-11-20 - [Use Button instead of .onTapGesture for Accessibility]
+**Learning:** Attaching `.onTapGesture` directly to structural views (like `HStack` or `VStack`) makes them interactive for mouse/touch users but entirely opaque to keyboard navigation (Tab key) and screen readers (VoiceOver). This is a major accessibility failure for lists and interactive cards.
+**Action:** When a view needs to act as a button, always wrap its contents in a `Button(action: {})` and apply `.buttonStyle(.plain)` if you need to preserve custom styling. Also, remember to include `.contentShape(Rectangle())` inside the button if you need empty space to remain tappable.

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -66,7 +66,8 @@ struct ChordRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
+            Button(action: onEdit) {
+                HStack {
                 HStack(spacing: 4) {
                     ForEach(Array(chord.buttons).sorted(by: { $0.category.chordDisplayOrder < $1.category.chordDisplayOrder }), id: \.self) { button in
 							ButtonIconView(button: button, isDualSense: isDualSense, isNintendo: isNintendo, isSteamController: isSteamController, isAppleTVRemote: isAppleTVRemote)
@@ -105,9 +106,10 @@ struct ChordRow: View {
                 }
 
                 Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {
@@ -213,7 +215,8 @@ struct SequenceRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
+            Button(action: onEdit) {
+                HStack {
                 HStack(spacing: 4) {
                     ForEach(Array(sequence.steps.enumerated()), id: \.offset) { index, button in
                         if index > 0 {
@@ -251,9 +254,10 @@ struct SequenceRow: View {
                 }
 
                 Spacer()
+                }
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {


### PR DESCRIPTION
💡 What: Replaced `.onTapGesture` with a proper `Button` wrapper for `ChordRow` and `SequenceRow`.
🎯 Why: `.onTapGesture` prevents interactive elements from properly supporting keyboard focus and VoiceOver accessibility. Using a Button with `.buttonStyle(.plain)` fixes this while maintaining visual appearance.
📸 Before/After: Not applicable (no visual change).
♿ Accessibility: Improved keyboard navigation and screen reader support for chord and sequence list rows.

---
*PR created automatically by Jules for task [13463346906967767145](https://jules.google.com/task/13463346906967767145) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation and VoiceOver support for chord and sequence list rows.
  * Made entire row content areas activate editing through standard buttons while preserving their tappable areas.
* **Documentation**
  * Added guidance for using accessible buttons instead of tap gestures on structural views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->