### PR TITLE
🎨 Palette: Improve interactive row accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -36,3 +36,6 @@
 ## 2024-05-18 - [SwiftUI Button Accessibility]
 **Learning:** Using `.onTapGesture` on generic views like `HStack` prevents interactive elements from properly supporting keyboard focus and VoiceOver accessibility.
 **Action:** Always wrap interactive list rows in a `Button` with `.buttonStyle(.plain)` instead of attaching `.onTapGesture` to views, ensuring `.contentShape(Rectangle())` is applied within the button to maintain the clickable area.
+## 2024-07-24 - Interactive Row Accessibility
+**Learning:** Using `.onTapGesture` on list rows or large UI elements prevents keyboard users from focusing and interacting with those elements, missing built-in accessibility traits.
+**Action:** Always wrap interactive areas in `Button` with `.buttonStyle(.plain)` and preserve `.contentShape(Rectangle())` inside the button label to ensure it remains fully clickable without visual regression.

--- a/TriggerKit/Sources/TriggerKitUI/AutomationProgramEditor.swift
+++ b/TriggerKit/Sources/TriggerKitUI/AutomationProgramEditor.swift
@@ -194,22 +194,24 @@ public struct AutomationProgramEditor: View {
 				.help(allowed ? (expanded ? "Collapse" : "Expand") : "Unavailable in this host")
 				.accessibilityLabel(allowed ? (expanded ? "Collapse" : "Expand") : "Unavailable in this host")
 
-				HStack(spacing: 8) {
-					Image(systemName: iconName(for: step))
-						.frame(width: 18)
-						.foregroundStyle(allowed ? Color.accentColor : Color.secondary)
+					Button {
+						if allowed {
+							toggleExpanded(index)
+						}
+					} label: {
+						HStack(spacing: 8) {
+							Image(systemName: iconName(for: step))
+								.frame(width: 18)
+								.foregroundStyle(allowed ? Color.accentColor : Color.secondary)
 
-					Text(step.displaySummary)
-						.font(.callout.weight(.semibold))
-						.lineLimit(1)
-						.frame(maxWidth: .infinity, alignment: .leading)
-				}
-				.contentShape(Rectangle())
-				.onTapGesture {
-					if allowed {
-						toggleExpanded(index)
+							Text(step.displaySummary)
+								.font(.callout.weight(.semibold))
+								.lineLimit(1)
+								.frame(maxWidth: .infinity, alignment: .leading)
+						}
+						.contentShape(Rectangle())
 					}
-				}
+					.buttonStyle(.plain)
 
 				Button {
 					moveStep(from: index, by: -1)


### PR DESCRIPTION
### 💡 What:
Replaced the `.onTapGesture` on the macro step summary row in `AutomationProgramEditor` with a standard SwiftUI `Button` using `.buttonStyle(.plain)`.

### 🎯 Why:
Using `.onTapGesture` on standard views like `HStack` makes them clickable for mouse users but completely hides them from keyboard navigation (Tab key) and screen readers. Wrapping the row in a button ensures all users can focus and interact with macro steps.

### ♿ Accessibility:
- **Keyboard Navigation:** Users can now use the Tab key to focus the step row and the Space/Enter key to expand/collapse it.
- **Screen Readers:** VoiceOver will now correctly identify the row as an interactive button rather than static text.
- **Preserved Hit Area:** Retained `.contentShape(Rectangle())` inside the button label to ensure the entire empty space of the row remains clickable, preventing a regression where only text/icons would be interactive.

---
*PR created automatically by Jules for task [10340320153669768033](https://jules.google.com/task/10340320153669768033) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard focus and accessibility support for interactive automation step rows.

* **Usability**
  * Step summaries can now be activated as clear button controls to expand or collapse eligible steps.
  * Preserved full-row clickability without changing the visual appearance.
  * Prevented expansion actions for steps that are not eligible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->