### PR TITLE
🎨 Palette: Improve accessibility of list items by replacing .onTapGesture with Button

### DIFF
--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -66,9 +66,10 @@ struct ChordRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
-                HStack(spacing: 4) {
-                    ForEach(Array(chord.buttons).sorted(by: { $0.category.chordDisplayOrder < $1.category.chordDisplayOrder }), id: \.self) { button in
+            Button(action: onEdit) {
+                HStack {
+                    HStack(spacing: 4) {
+                        ForEach(Array(chord.buttons).sorted(by: { $0.category.chordDisplayOrder < $1.category.chordDisplayOrder }), id: \.self) { button in
 							ButtonIconView(button: button, isDualSense: isDualSense, isNintendo: isNintendo, isSteamController: isSteamController, isAppleTVRemote: isAppleTVRemote)
                     }
                 }
@@ -107,7 +108,8 @@ struct ChordRow: View {
                 Spacer()
             }
             .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {
@@ -213,7 +215,8 @@ struct SequenceRow: View {
                 .accessibilityHidden(true)
 
             // Tappable content area
-            HStack {
+            Button(action: onEdit) {
+                HStack {
                 HStack(spacing: 4) {
                     ForEach(Array(sequence.steps.enumerated()), id: \.offset) { index, button in
                         if index > 0 {
@@ -253,7 +256,8 @@ struct SequenceRow: View {
                 Spacer()
             }
             .contentShape(Rectangle())
-            .onTapGesture { onEdit() }
+            }
+            .buttonStyle(.plain)
 
             HStack(spacing: 12) {
                 Button(action: onEdit) {

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift
@@ -217,17 +217,17 @@ struct SequenceRow: View {
             // Tappable content area
             Button(action: onEdit) {
                 HStack {
-                HStack(spacing: 4) {
-                    ForEach(Array(sequence.steps.enumerated()), id: \.offset) { index, button in
-                        if index > 0 {
-                            Image(systemName: "arrow.right")
-                                .font(.system(size: 9))
-                                .foregroundColor(.white.opacity(0.3))
-                                .accessibilityHidden(true)
-                        }
+                    HStack(spacing: 4) {
+                        ForEach(Array(sequence.steps.enumerated()), id: \.offset) { index, button in
+                            if index > 0 {
+                                Image(systemName: "arrow.right")
+                                    .font(.system(size: 9))
+                                    .foregroundColor(.white.opacity(0.3))
+                                    .accessibilityHidden(true)
+                            }
 							ButtonIconView(button: button, isDualSense: isDualSense, isNintendo: isNintendo, isSteamController: isSteamController, isAppleTVRemote: isAppleTVRemote)
+                        }
                     }
-                }
 
                 Image(systemName: "arrow.right")
                     .font(.caption2)

--- a/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/RecommendationsSheet.swift
+++ b/XboxControllerMapper/XboxControllerMapper/Views/MainWindow/RecommendationsSheet.swift
@@ -91,43 +91,44 @@ struct RecommendationsSheet: View, ControllerTypeProviding {
 	) -> some View {
         let isSelected = selectedIds.contains(rec.id)
 
-        return HStack(spacing: 10) {
-            // Checkbox
-            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                .font(.system(size: 18))
-                .foregroundColor(isSelected ? .accentColor : .secondary)
-                .onTapGesture { toggleSelection(rec.id) }
+        return Button(action: { toggleSelection(rec.id) }) {
+            HStack(spacing: 10) {
+                // Checkbox
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 18))
+                    .foregroundColor(isSelected ? .accentColor : .secondary)
 
-            // Type icon
-            typeIcon(for: rec.type)
+                // Type icon
+                typeIcon(for: rec.type)
 
-            // Recommendation content
-            VStack(alignment: .leading, spacing: 6) {
-                // Title line
-				titleView(for: rec, presentationState: presentationState)
+                // Recommendation content
+                VStack(alignment: .leading, spacing: 6) {
+                    // Title line
+					titleView(for: rec, presentationState: presentationState)
 
-                // Before → After with button icons
-				beforeAfterView(for: rec, presentationState: presentationState)
+                    // Before → After with button icons
+					beforeAfterView(for: rec, presentationState: presentationState)
+                }
+
+                Spacer()
+
+                // Priority indicator
+                Circle()
+                    .fill(priorityColor(rec.priority))
+                    .frame(width: 8, height: 8)
             }
-
-            Spacer()
-
-            // Priority indicator
-            Circle()
-                .fill(priorityColor(rec.priority))
-                .frame(width: 8, height: 8)
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(isSelected ? Color.accentColor.opacity(0.08) : Color.white.opacity(0.03))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+            )
+            .contentShape(Rectangle())
         }
-        .padding(10)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(isSelected ? Color.accentColor.opacity(0.08) : Color.white.opacity(0.03))
-        )
-        .overlay(
-            RoundedRectangle(cornerRadius: 8)
-                .stroke(isSelected ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
-        )
-        .contentShape(Rectangle())
-        .onTapGesture { toggleSelection(rec.id) }
+        .buttonStyle(.plain)
     }
 
 	@ViewBuilder

--- a/fix_indent_all.py
+++ b/fix_indent_all.py
@@ -1,0 +1,24 @@
+import sys
+import re
+
+filepath = 'XboxControllerMapper/XboxControllerMapper/Views/MainWindow/ChordSequenceListViews.swift'
+
+with open(filepath, 'r') as f:
+    content = f.read()
+
+content = content.replace(r"""                        ForEach(Array(sequence.steps.enumerated()), id: \.offset) { index, button in
+                        if index > 0 {
+                            Image(systemName: "arrow.right")
+                                .font(.system(size: 9))
+                                .foregroundColor(.white.opacity(0.3))
+                                .accessibilityHidden(true)
+                        }""", r"""                        ForEach(Array(sequence.steps.enumerated()), id: \.offset) { index, button in
+                            if index > 0 {
+                                Image(systemName: "arrow.right")
+                                    .font(.system(size: 9))
+                                    .foregroundColor(.white.opacity(0.3))
+                                    .accessibilityHidden(true)
+                            }""")
+
+with open(filepath, 'w') as f:
+    f.write(content)


### PR DESCRIPTION
💡 **What**: Replaced `.onTapGesture` on list items in `ChordSequenceListViews.swift` and `RecommendationsSheet.swift` with standard `Button` components using `.buttonStyle(.plain)`.
🎯 **Why**: Using `.onTapGesture` prevents standard keyboard navigation (Tab key to focus) and makes the element opaque to VoiceOver screen readers, creating an accessibility barrier for users who rely on keyboards or assistive technologies. Wrapping the content in a native `Button` ensures these elements are recognized as interactive controls.
📸 **Before/After**: No visual change; purely an accessibility and interaction improvement.
♿ **Accessibility**: Interactive list rows are now reachable via keyboard (Tab) and correctly announced by screen readers as actionable buttons.

---
*PR created automatically by Jules for task [5533532803301851540](https://jules.google.com/task/5533532803301851540) started by @NSEvent*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Usability Improvements**
  * Improved tap handling for editing chord and sequence entries.
  * Made entire recommendation rows selectable, providing a more consistent interaction experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->